### PR TITLE
Prevent executor/mech-executor from polling long-running processes

### DIFF
--- a/templates/agents/executor.md
+++ b/templates/agents/executor.md
@@ -11,4 +11,6 @@ Work like a senior engineer on a well-scoped ticket: read enough context to matc
 
 Escalate instead of guessing when you hit a genuine architecture fork (two approaches with codebase-wide consequences) or when the task conflicts with something the spec didn't anticipate — report the fork and your recommendation, then stop.
 
+Never babysit a long-running process. If a command will run more than a few minutes, launch it detached (nohup + log file), sanity-check the first minutes, then END YOUR TURN reporting PID + log path — the orchestrator monitors and dispatches follow-up. Never poll in a wait loop: if you notice yourself checking a still-running process repeatedly, that is the signal to stop and return a status report instead. One check, then yield.
+
 Your final message: outcome first (what now works, verified how), then notable decisions you made and why, then anything deferred or flagged.

--- a/templates/agents/mech-executor.md
+++ b/templates/agents/mech-executor.md
@@ -11,4 +11,6 @@ Follow the spec's conventions and the surrounding code style precisely. Verify y
 
 If the spec turns out to be ambiguous or wrong mid-task (a named file doesn't exist, the pattern has unstated exceptions, tests fail for reasons outside your scope), stop and report exactly what you found instead of guessing — the orchestrator will re-spec. A precise "blocked because X" is a successful outcome; a guessed implementation is not.
 
+Never babysit a long-running process. If a command will run more than a few minutes, launch it detached (nohup + log file), sanity-check the first minutes, then END YOUR TURN reporting PID + log path — the orchestrator monitors and dispatches follow-up. Never poll in a wait loop: one check, then yield with a status report.
+
 Your final message: what was changed (files + one line each), what was verified and how, and anything deferred.


### PR DESCRIPTION
Closes #2.

## Summary
- `executor` and `mech-executor` had no guidance for long-running commands, so a subagent would start a build/test/server and then keep checking on it inside its own turn instead of yielding — a self-directed wait loop that stalls the delegation and burns tokens.
- Both templates now instruct the agent to launch anything over a few minutes detached (nohup + log file), do one sanity check, then end the turn reporting PID + log path so the orchestrator can monitor and dispatch follow-up.

I've run this addition locally on both agents for a few days and it eliminated the poll-loop behavior in practice.

## Test plan
- [x] Diff reviewed for scope (only the two agent templates touched, no version/changelog bump — left for maintainer)
- [ ] Maintainer smoke-tests a delegated long-running task (e.g. a slow test suite) against the updated `executor` template