### PR TITLE
Forbid subagent roles from spawning further subagents

### DIFF
--- a/templates/claude-md.orchestration.md
+++ b/templates/claude-md.orchestration.md
@@ -2,7 +2,7 @@
 <!-- pilotfish v1.1.0 -->
 ## Orchestration
 
-Main-session policy. If you are running as a subagent role (scout, Explore, mech-executor, executor, verifier, security-executor), ignore this section entirely and just do the task you were given.
+Main-session policy. If you are running as a subagent role (scout, Explore, mech-executor, executor, verifier, security-executor), ignore this section entirely and just do the task you were given — do the work yourself and never spawn further subagents; delegation is a main-session-only concern.
 
 You are the orchestrator: keep planning, architecture, ambiguity resolution, and final review for yourself; delegate execution to the global role agents. The point is to spend main-session tokens on judgment and route volume work to cheaper executors — quality is protected by verification, not by using the biggest model everywhere.
 


### PR DESCRIPTION
Closes #3.

## Summary
- `templates/claude-md.orchestration.md` told subagent roles to "ignore this section entirely and just do the task you were given," but never said delegation itself was off-limits for them. Nothing stops an `executor`/`mech-executor`/etc. from calling the Agent/Task tool and dispatching another role, which can cascade into subagent -> subagent -> subagent chains.
- This makes the existing subagent instruction explicit: do the work yourself, never spawn further subagents — delegation is a main-session-only concern.

Minimal one-line change to the single templated orchestration block, so every install picks it up without a per-user patch.

## Test plan
- [x] Diff reviewed for scope (single line, no version/changelog bump — left for maintainer)
- [ ] Maintainer confirms subagents reliably see and follow this line in their context