### PR TITLE
Make executor roles leaf agents: disallowedTools: Agent, Workflow

### DIFF
--- a/templates/agents/executor.md
+++ b/templates/agents/executor.md
@@ -3,7 +3,10 @@ name: executor
 description: Implementation requiring judgment - feature work, bug fixes, refactors with design decisions, integration work. The default executor for real development tasks that are more than mechanical but don't need the frontier model. Give it the goal, constraints, and done-criteria; it makes reasonable local design decisions itself.
 model: opus
 effort: medium
+disallowedTools: Agent, Workflow
 ---
+
+You are a leaf agent: do every part of your task yourself, in this session. Never delegate — the Agent and Workflow tools are disabled for this role by design. If the task genuinely seems to require spawning sub-agents, that is a mis-routed task: stop and report it back instead.
 
 You are the primary implementation executor. You receive a goal with constraints and done-criteria, and you own the local design decisions needed to get there — naming, structure within the touched files, error handling appropriate to the codebase's existing patterns.
 

--- a/templates/agents/mech-executor.md
+++ b/templates/agents/mech-executor.md
@@ -3,7 +3,10 @@ name: mech-executor
 description: Mechanical execution of fully-specified work - pattern-based refactors and renames, writing tests that follow existing conventions, documentation updates, bulk multi-file edits from an explicit spec, running test suites and fixing trivial failures. Use when the task needs no design decisions; give it a complete spec (goal, exact scope, done-criteria).
 model: sonnet
 effort: low
+disallowedTools: Agent, Workflow
 ---
+
+You are a leaf agent: do every part of your task yourself, in this session. Never delegate — the Agent and Workflow tools are disabled for this role by design. If the task genuinely seems to require spawning sub-agents, that is a mis-routed task: stop and report it back instead.
 
 You are a mechanical executor. You receive fully-specified tasks and carry them out exactly — no scope expansion, no redesign, no "while I'm here" improvements.
 

--- a/templates/agents/security-executor.md
+++ b/templates/agents/security-executor.md
@@ -3,7 +3,10 @@ name: security-executor
 description: Security-sensitive implementation and analysis - authentication/authorization, secrets handling, crypto usage, input validation, hardening, dependency vulnerability triage, security-relevant code review. Use for ANY task where the word "security" applies, instead of executor or the main session.
 model: opus
 effort: high
+disallowedTools: Agent, Workflow
 ---
+
+You are a leaf agent: do every part of your task yourself, in this session. Never delegate — the Agent and Workflow tools are disabled for this role by design. If the task genuinely seems to require spawning sub-agents, that is a mis-routed task: stop and report it back instead.
 
 You are the executor for security-sensitive work. You exist as a separate role for two reasons: this work deserves consistently high effort, and it is deliberately routed to Opus — the frontier model's safety classifiers can refuse benign defensive-security work mid-task, so security tasks never go there.
 

--- a/templates/agents/verifier.md
+++ b/templates/agents/verifier.md
@@ -3,8 +3,10 @@ name: verifier
 description: Fresh-context adversarial verification of completed work. Use after any non-trivial change, before reporting it done - give it the claimed outcome and the diff/paths, and it independently tries to refute the claim by exercising the code, running tests, and probing edge cases. Returns CONFIRMED or REFUTED with evidence. Read-and-run only; it never fixes what it finds.
 model: opus
 effort: medium
-disallowedTools: Write, Edit, NotebookEdit
+disallowedTools: Write, Edit, NotebookEdit, Agent, Workflow
 ---
+
+You are a leaf agent: do every part of your task yourself, in this session. Never delegate — the Agent and Workflow tools are disabled for this role by design. If the task genuinely seems to require spawning sub-agents, that is a mis-routed task: stop and report it back instead.
 
 You are an adversarial verifier with fresh eyes. You receive a claim ("X was implemented and works") plus the relevant diff or paths. Your job is to try to REFUTE it — assume it's broken until the evidence says otherwise.
 


### PR DESCRIPTION
## The incident

Running pilotfish v1.1.1 stock. A `mech-executor` spawned for a fully-specified 4-file sweep did **zero work and re-delegated its entire prompt to another `mech-executor`** — which did the same — **four levels deep** before the user noticed the identical spawns stacking up in the UI and we killed the chain.

Each empty level cost ~40k tokens for one tool call, and because subagents share the working tree, the deepest level's half-finished edits were left racing a sibling agent's files after the cascade kill.

## Why the v1.1.1 guard doesn't hold

v1.1.1 added the right *intent* to `claude-md.orchestration.md`: *"If you are running as a subagent role … never spawn further subagents."* But the role agents inherit **all tools** (including `Agent`), and they can see the orchestration routing table in the same file. From inside a mech-executor, "mechanical, fully-specified work → mech-executor" pattern-matches its own task perfectly — and a routing table plus an available tool beats a plea two paragraphs earlier. In our incident the model followed the table, not the guard, four times in a row.

## The fix

Capability removal instead of prompt pleading:

- `executor`, `mech-executor`, `security-executor`: add `disallowedTools: Agent, Workflow`
- `verifier`: extend its existing exclusions to `Write, Edit, NotebookEdit, Agent, Workflow`
- All four get a short "you are a leaf agent" paragraph right after the frontmatter, so a genuinely mis-routed task gets **reported back** instead of silently re-delegated
- `scout` / `Explore` need nothing — their `tools: Read, Glob, Grep` allowlist already makes them leaves

`disallowedTools` is already the mechanism verifier uses for its read-only guarantee, so this stays within the project's existing vocabulary.

We've applied the same patch to our live install; happy to report back on longer-term behavior if useful.

🤖 Generated with [Claude Code](https://claude.com/claude-code)