### PR TITLE
docs: add release version stamp check

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -5,7 +5,15 @@ Maintainer checklist — the three version stamps must move together:
 1. Bump `VERSION`.
 2. Update the version comment in `templates/claude-md.orchestration.md` (`<!-- pilotfish vX.Y.Z -->`), and mirror the block into your own `~/.claude/CLAUDE.md`.
 3. Add the `CHANGELOG.md` entry (what changed, why — users see this during update).
-4. Commit, then tag and publish:
+4. Verify the repo stamps agree:
+
+```bash
+version="$(cat VERSION)"
+grep -q "<!-- pilotfish v${version} -->" templates/claude-md.orchestration.md
+grep -q "## v${version} " CHANGELOG.md
+```
+
+5. Commit, then tag and publish:
 
 ```bash
 git tag vX.Y.Z


### PR DESCRIPTION
## Summary
- add a release checklist command to verify VERSION, the policy-block version comment, and CHANGELOG heading stay synchronized before tagging

## Verification
- `version="1.1.4"; grep -q "<!-- pilotfish v -->" templates/claude-md.orchestration.md; grep -q "## v " CHANGELOG.md`