### PR TITLE
docs: credit Baton lifecycle provenance

### DIFF
--- a/benchmarks/baton-compatibility/README.md
+++ b/benchmarks/baton-compatibility/README.md
@@ -18,6 +18,28 @@ This experiment tests whether [Baton](https://github.com/cablate/baton) and the 
 
 The fixture is the [two-surface research control](../dispatch-brake/positive-controls/research/fixture) first published in pilotfish commit `5f027b8c`. The run used Claude Code 2.1.207, native first-party Claude authentication, the PR #10 candidate policy, and the installed Baton skill whose `SKILL.md` SHA-256 is recorded in [`results.json`](./results.json).
 
+### Design provenance
+
+One direct design input for this five-stage lifecycle came from [CabLate](https://github.com/cablate), author of [Baton](https://github.com/cablate/baton), during a July 13, 2026 discussion about delegation boundaries in large legacy-code refactors. A faithful English translation follows; the [Traditional Chinese report](./README.zh-TW.md#設計緣起) preserves the original wording:
+
+> Large projects have a prerequisite: the scope needs to be defined. In my legacy-code refactoring example, Baton would first dispatch research agents according to my current request and the goal of that phase, so they could understand the project's current state and analyze how to delegate the work that follows.
+>
+> An ideal flow, then, should look like this:
+>
+> The user submits a request
+>
+> -> Baton plans how to delegate agents to understand the request
+>
+> -> After the agents return with what they found, the main session writes a Plan
+>
+> (During this process, Baton may still delegate a verification agent to validate the Plan in detail)
+>
+> -> The user approves execution of the Plan, and Baton executes the best delegation strategy based on that Plan
+
+— [CabLate](https://github.com/cablate), July 13, 2026; translated from the [Traditional Chinese original](./README.zh-TW.md#設計緣起).
+
+That workflow was later formalized as Discovery → Plan → Approval → Execution → Verification and became the backbone of the composition contract below.
+
 ## Composition contract
 
 ```mermaid

--- a/benchmarks/baton-compatibility/README.zh-TW.md
+++ b/benchmarks/baton-compatibility/README.zh-TW.md
@@ -18,6 +18,28 @@
 
 Fixture 是最早發佈於 pilotfish commit `5f027b8c` 的[雙 surface 研究 control](../dispatch-brake/positive-controls/research/fixture)。執行環境為 Claude Code 2.1.207、原生 first-party Claude authentication、PR #10 candidate policy，以及 `SKILL.md` SHA-256 記錄於 [`results.json`](./results.json) 的 Baton skill。
 
+### 設計緣起
+
+這個五階段 lifecycle 的直接設計來源之一，是 [Baton](https://github.com/cablate/baton) 原作者 [CabLate](https://github.com/cablate) 在 2026-07-13 討論大型 Legacy code 重構與 Agent 委派邊界時提出的流程。以下保留原始回覆：
+
+> 大型的專案有個先決條件是把範圍訂下來，以我重構 Legacy code 的例子，Baton 會根據我當下的需求與該階段的目標，先派出研究用的 agent 理解專案現況，並分析後續要怎麼委派。
+>
+> 所以一個比較理想的流程應該是要這樣：
+>
+> 使用者提出一個需求
+>
+> -> 透過 Baton 去規劃如何委派 Agent 理解這個需求
+>
+> -> Agent們捕獲到實際情況回來後，主 session 撰寫一份 Plan
+>
+> (這過程為了詳細驗證 Plan 的可靠性，Baton可能還是會委派驗證用的 Agent)
+>
+> -> 使用者允許 Plan 執行，Baton 根據 Plan 執行最佳委派方案
+
+— [CabLate](https://github.com/cablate)，2026-07-13
+
+這段流程後來被具體化為 Discovery → Plan → Approval → Execution → Verification，並成為下方合成契約的骨架。
+
 ## 合成契約
 
 ```mermaid


### PR DESCRIPTION
## What changed

Add a design-provenance note immediately before the composition contract in both pilotfish + Baton compatibility reports.

| Surface | Change |
|---|---|
| Traditional Chinese report | Preserve CabLate's July 13, 2026 reply verbatim and identify CabLate as the author of Baton |
| English report | Add a faithful translation, label it as a translation, and link back to the Traditional Chinese original |
| Document flow | Place the provenance after the experiment purpose and fixture, then transition directly into the five-stage contract it informed |

The attribution links both [CabLate](https://github.com/cablate) and [Baton](https://github.com/cablate/baton). No orchestration policy, role definition, benchmark result, snapshot, or machine-readable evidence changes.

## Why

PR #10 formalized the phase-aware Baton lifecycle as Discovery → Plan → Approval → Execution → Verification, but the reports do not currently record where this part of the design discussion came from.

Before that lifecycle was formalized, CabLate described the large-project prerequisite as defining scope first, using read-only research agents to understand the real project, keeping Plan synthesis in the main session, optionally challenging the Plan with a verifier, waiting for user approval, and only then choosing the execution topology. The author of pilotfish asked CabLate to preserve that original reply in the docs so the attribution would live with the resulting contract instead of remaining only in the community conversation.

| Original idea | v1.2.0 form |
|---|---|
| Define the phase scope before delegating | Phase-specific stability contracts |
| Research agents first inspect the real project | Discovery |
| The main session writes the Plan | Plan synthesis remains in the main session |
| A verifier may challenge Plan reliability | Read-only `plan-verifier` with `READY` / `REVISE` |
| The user permits execution | Explicit Approval gate before writes |
| Baton chooses the best delegation after approval | Execution receives a stable approved contract |

Keeping this note between Purpose and Composition contract makes the reading order explicit: tested context → design provenance → formal contract. The bilingual treatment also avoids presenting the English translation as CabLate's original wording.

## Scope and disclosure

- The Traditional Chinese blockquote matches the supplied original reply exactly.
- The English blockquote is explicitly labeled as a translation and links to the original.
- The public attribution is limited to the discussion date, CabLate's GitHub profile, and the Baton repository.
- The change does not alter any Gate claim, measurement, limitation, or recorded hash.

## Checks

```text
python3 -m unittest discover -s tests -v
13 tests passed

both reports rendered through the GitHub Markdown API
24 relative Markdown links and anchors resolved
Traditional Chinese quote exactness check passed
git diff --check passed
```

The repository tests were run from an LF-preserving Git-index export under Ubuntu because their snapshot and generated-output checks are byte-exact; the host Windows Git installation has global `core.autocrlf=true`.
