### PR TITLE
docs: disclose Claude Pro agent opt-in requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,16 +53,19 @@ Two subscription-specific bonuses stack on top:
 
 Three layers, three files' worth of configuration, all under `~/.claude/`:
 
-> ⚠️ **Claude Pro currently requires explicit opt-in for Agent dispatch.**
-> On the tested first-party Pro account, Claude Code 2.1.220's higher-priority
+> ⚠️ **Explicit Agent opt-in was required on one tested Claude Pro setup.**
+> On one first-party Pro account running Claude Code 2.1.220, a higher-priority
 > Agent tool contract blocked spawning unless the user explicitly requested
-> agents. A user-level `CLAUDE.md` cannot override that contract, so a successful
-> pilotfish install does not guarantee cue-free delegation. Add
+> agents. A user-level `CLAUDE.md` could not override that session contract, so
+> a successful pilotfish install does not guarantee cue-free delegation in every
+> environment. Add
 > `Use pilotfish and delegate eligible work to the named agents.` to the request
-> when you want the orchestration lifecycle. Explicitly directed roles remain
-> reachable; both the v1.3.4 compressed candidate and unchanged v1.3.3 cue-free
-> control recorded zero dispatch, so this limitation is not attributed to prompt
-> compression. Tracking: [#29](https://github.com/Nanako0129/pilotfish/issues/29).
+> when you want the orchestration lifecycle. Explicit direction reached the
+> exercised `scout`, `plan-verifier`, `mech-executor`, and `verifier` paths;
+> other roles were not tested. Both the v1.3.4 compressed candidate and unchanged
+> v1.3.3 cue-free control recorded zero dispatch, so this observation is not
+> attributed to prompt compression. Tracking:
+> [#29](https://github.com/Nanako0129/pilotfish/issues/29).
 
 | Layer | File(s) | Job |
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -53,6 +53,17 @@ Two subscription-specific bonuses stack on top:
 
 Three layers, three files' worth of configuration, all under `~/.claude/`:
 
+> ⚠️ **Claude Pro currently requires explicit opt-in for Agent dispatch.**
+> On the tested first-party Pro account, Claude Code 2.1.220's higher-priority
+> Agent tool contract blocked spawning unless the user explicitly requested
+> agents. A user-level `CLAUDE.md` cannot override that contract, so a successful
+> pilotfish install does not guarantee cue-free delegation. Add
+> `Use pilotfish and delegate eligible work to the named agents.` to the request
+> when you want the orchestration lifecycle. Explicitly directed roles remain
+> reachable; both the v1.3.4 compressed candidate and unchanged v1.3.3 cue-free
+> control recorded zero dispatch, so this limitation is not attributed to prompt
+> compression. Tracking: [#29](https://github.com/Nanako0129/pilotfish/issues/29).
+
 | Layer | File(s) | Job |
 |---|---|---|
 | Machine | `~/.claude/settings.json` | Who orchestrates (`opus`) + automatic `fallbackModel` chain |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -53,14 +53,16 @@ Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-o
 
 三層架構、三處設定，全部在 `~/.claude/` 底下：
 
-> ⚠️ **Claude Pro 目前需要明確 opt-in 才能委派 Agent。**
-> 在已測試的 first-party Pro 帳號上，Claude Code 2.1.220 較高優先級的
+> ⚠️ **一個已測試的 Claude Pro 環境需要明確 opt-in 才能委派 Agent。**
+> 在一個使用 Claude Code 2.1.220 的 first-party Pro 帳號上，較高優先級的
 > Agent tool contract 會阻止 spawn，除非使用者明確要求 agents。使用者層的
-> `CLAUDE.md` 無法覆蓋這份 contract，因此成功安裝 pilotfish 不代表一定會
-> 無提示自動委派。需要 orchestration lifecycle 時，請在 request 加上
-> `Use pilotfish and delegate eligible work to the named agents.`。明確指定後，
-> roles 仍可正常啟動；v1.3.4 壓縮版與未修改的 v1.3.3 cue-free control 都是
-> 0 dispatch，因此目前不把此限制歸因於 prompt compression。追蹤：
+> `CLAUDE.md` 無法覆蓋該 session contract，因此成功安裝 pilotfish 不代表
+> 所有環境都會無提示自動委派。需要 orchestration lifecycle 時，請在 request
+> 加上 `Use pilotfish and delegate eligible work to the named agents.`。
+> 明確指定後，已實測的 `scout`、`plan-verifier`、`mech-executor` 與
+> `verifier` paths 可正常啟動；其他 roles 未測。v1.3.4 壓縮版與未修改的
+> v1.3.3 cue-free control 都是 0 dispatch，因此目前不把此觀察歸因於
+> prompt compression。追蹤：
 > [#29](https://github.com/Nanako0129/pilotfish/issues/29)。
 
 | 層 | 檔案 | 職責 |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -53,6 +53,16 @@ Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-o
 
 三層架構、三處設定，全部在 `~/.claude/` 底下：
 
+> ⚠️ **Claude Pro 目前需要明確 opt-in 才能委派 Agent。**
+> 在已測試的 first-party Pro 帳號上，Claude Code 2.1.220 較高優先級的
+> Agent tool contract 會阻止 spawn，除非使用者明確要求 agents。使用者層的
+> `CLAUDE.md` 無法覆蓋這份 contract，因此成功安裝 pilotfish 不代表一定會
+> 無提示自動委派。需要 orchestration lifecycle 時，請在 request 加上
+> `Use pilotfish and delegate eligible work to the named agents.`。明確指定後，
+> roles 仍可正常啟動；v1.3.4 壓縮版與未修改的 v1.3.3 cue-free control 都是
+> 0 dispatch，因此目前不把此限制歸因於 prompt compression。追蹤：
+> [#29](https://github.com/Nanako0129/pilotfish/issues/29)。
+
 | 層 | 檔案 | 職責 |
 |---|---|---|
 | 機器層 | `~/.claude/settings.json` | 決定誰當 orchestrator（`opus`）＋自動 `fallbackModel` 切換鏈 |


### PR DESCRIPTION
## Summary

- Document the Claude Pro requirement for explicit Agent-dispatch opt-in in both READMEs.
- Provide a request-level workaround for users who want the orchestration lifecycle.
- Link issue #29 and state the tested evidence boundary: both the v1.3.4 compressed candidate and unchanged v1.3.3 control recorded zero cue-free dispatch.

## Why

On the tested first-party Pro account with Claude Code 2.1.220, the higher-priority Agent tool contract blocks spawning unless the user explicitly requests agents. A user-level CLAUDE.md cannot override that contract, so installation alone does not guarantee cue-free delegation.

## Validation

- python3 -m unittest discover -s tests -v (29 tests passed)
- git diff --check

Related to #29.