### PR TITLE
test(release): enforce changelog version stamp

### DIFF
--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -843,6 +843,9 @@ class PolicyContractTests(unittest.TestCase):
         )
         self.assertIn(f"<!-- pilotfish v{version} -->", policy)
 
+        changelog = (ROOT / "CHANGELOG.md").read_text(encoding="utf-8")
+        self.assertRegex(changelog, rf"(?m)^## v{re.escape(version)} ")
+
         for readme in ("README.md", "README.zh-TW.md"):
             content = (ROOT / readme).read_text(encoding="utf-8")
             self.assertIn(f"git clone --branch v{version} --depth 1", content)


### PR DESCRIPTION
## Summary

- Extend the existing version-stamp contract test to require a `CHANGELOG.md` heading for the exact `VERSION` value.
- Keep the dependency-free Python test suite as the single release gate instead of adding duplicate shell checks to `RELEASING.md`.

## Why

PR #9 identified a real gap: a release could update `VERSION`, the policy stamp, and README clone pins while omitting the matching changelog heading. Its shell implementation now conflicts with `main` and can hide a failed first `grep`, so this replacement enforces the same requirement at the existing source of truth.

A version bump without a matching `## vX.Y.Z ` changelog heading now fails `test_version_stamps_move_together`.

## Validation

- `python3 -m unittest tests.test_policy.PolicyContractTests.test_version_stamps_move_together -v` — 1 passed
- `python3 -m unittest discover -s tests -v` — 33 passed
- `git diff --check origin/main...HEAD`
- Fresh outcome verification — `CONFIRMED`

## Attribution

The original release-contract gap was reported by @CooperSheroy in #9. This PR supersedes that PR's implementation while preserving its intended protection. The rebased commit also records `Reported-by: @CooperSheroy`.