### PR TITLE
docs: add Ko-fi sponsorship details

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+ko_fi: nanako0129

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@
 - [Research & design](#research--design)
 - [Contributing](#contributing)
 - [Uninstall](#uninstall)
+- [Support pilotfish](#support-pilotfish)
 - [License](#license)
 
 ## Why
@@ -262,6 +263,22 @@ Uninstall pilotfish: remove the eight pilotfish agent files from ~/.claude/agent
 delete the <!-- pilotfish:begin --> ... <!-- pilotfish:end --> block from ~/.claude/CLAUDE.md,
 and offer to restore my previous "model" / remove "fallbackModel" in ~/.claude/settings.json.
 ```
+
+## Support pilotfish
+
+pilotfish is only configuration, but proving that its policy still works is not
+free. Meaningful compatibility claims require paid Claude Code or API runs
+across multiple model tiers, multi-turn dispatch Gates, and fresh independent
+verifier sessions. Runs that hit quota limits or expose a policy flaw are
+disclosed and rerun rather than counted as proof.
+
+Sponsorship helps cover those model credits and the ongoing work of tracking
+Claude Code changes, provider aliases, role templates, installer behavior, and
+[release evidence](./benchmarks/baton-dispatch-effect/README.md). If pilotfish
+saves you quota or review time, you can support its continued development on
+Ko-fi.
+
+[![Support pilotfish on Ko-fi](https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/nanako0129)
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -270,7 +270,7 @@ pilotfish is only configuration, but proving that its policy still works is not
 free. Meaningful compatibility claims require paid Claude Code or API runs
 across multiple model tiers, multi-turn dispatch Gates, and fresh independent
 verifier sessions. Runs that hit quota limits or expose a policy flaw are
-disclosed and rerun rather than counted as proof.
+disclosed and, when feasible, rerun rather than counted as proof.
 
 Sponsorship helps cover those model credits and the ongoing work of tracking
 Claude Code changes, provider aliases, role templates, installer behavior, and

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -25,6 +25,7 @@
 - [研究與設計](#研究與設計)
 - [參與貢獻](#參與貢獻)
 - [移除](#移除)
+- [支持 pilotfish](#支持-pilotfish)
 - [授權](#授權)
 
 ## 為什麼
@@ -260,6 +261,14 @@ Uninstall pilotfish: remove the eight pilotfish agent files from ~/.claude/agent
 delete the <!-- pilotfish:begin --> ... <!-- pilotfish:end --> block from ~/.claude/CLAUDE.md,
 and offer to restore my previous "model" / remove "fallbackModel" in ~/.claude/settings.json.
 ```
+
+## 支持 pilotfish
+
+pilotfish 本身只有設定檔，但要證明政策仍能正確運作並不是免費的。具實質意義的相容性宣稱，需要在多個模型等級上執行付費的 Claude Code 或 API 測試、多回合 dispatch Gate，以及全新且獨立的 verifier session。遇到額度限制或暴露政策缺陷的執行，會明確揭露，並在可行時重新執行，而不會直接算成通過證據。
+
+贊助會用於支付這些模型額度，以及持續追蹤 Claude Code 變更、provider alias、role template、installer 行為與[發版證據](./benchmarks/baton-dispatch-effect/README.md)的維護工作。如果 pilotfish 幫你節省了額度或 review 時間，可以透過 Ko-fi 支持後續開發。
+
+[![在 Ko-fi 支持 pilotfish](https://img.shields.io/badge/Support_on_Ko--fi-FF5E5B?style=for-the-badge&logo=ko-fi&logoColor=white)](https://ko-fi.com/nanako0129)
 
 ## 授權
 


### PR DESCRIPTION
## Summary

- add `.github/FUNDING.yml` for the `nanako0129` Ko-fi page
- add project-specific sponsorship sections to the English and Traditional Chinese READMEs
- explain the paid compatibility and verification work behind pilotfish without claiming that every quota-blocked run can be rerun

## Why

pilotfish is configuration-only, but its behavioral claims depend on paid multi-model Gates, quota-limited attempts, and fresh independent verifier sessions. The repository should explain that maintenance cost where users encounter the project, keep both public README languages aligned, and provide a direct support path.

## Scope

This changes GitHub funding metadata and the bilingual public READMEs only. It does not change the orchestration policy, role templates, installer behavior, historical evidence, or runtime configuration.

## Verification

- `python3 -m unittest discover -s tests -v` — 29 tests passed before the initial push and after the review fixes
- `git diff --check origin/main...HEAD` — passed
- confirmed the branch changes only `.github/FUNDING.yml`, `README.md`, and `README.zh-TW.md`
- no paid or live behavioral Gate was run for this documentation-only change

## Review follow-up

The current head mirrors the sponsorship section into `README.zh-TW.md` and qualifies reruns as occurring when feasible, matching the published Fable usage-credit disposition.

## Automation disclosure

This documentation change was authored with Codex assistance. The final diff, bilingual alignment, repository tests, link target, and commit scope were independently checked locally.