### PR TITLE
docs(install): resolve CLAUDE_CONFIG_DIR instead of hardcoding ~/.claude

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ The raw `main` prompt in [Install](#install) remains a mutable convenience path,
 
 | Want to… | How |
 |---|---|
-| Check what you have installed | `grep -o "pilotfish v[0-9.]*" ~/.claude/CLAUDE.md` — no output with markers present = pre-v1.1.0, update recommended |
+| Check what you have installed | `CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; grep -o "pilotfish v[0-9.]*" "$CFG/CLAUDE.md"` — no output with markers present = pre-v1.1.0, update recommended |
 | Get notified of new releases | GitHub → **Watch → Custom → Releases** on this repo |
 | See what changed | [CHANGELOG.md](./CHANGELOG.md) — every release is also a git tag |
 | Stay frozen on a reviewed version | Install pinned to a tag or SHA (see [Trust & security](#trust--security)); pinned installs never move until you re-pin |
@@ -230,11 +230,11 @@ The delegation policy in `CLAUDE.md` speaks only of roles (`executor`, `scout`, 
 | Which effort for the main session? | Start with `high` for judgment-heavy orchestration and lower it when quota or latency matters more. If you opt into Fable, follow its model-specific prompting guidance. |
 | How do I request a 1M context window? | The plain `opus` alias follows the provider default. If you need to request 1M explicitly on a supported provider, set `model` to `"opus[1m]"`; pilotfish leaves an existing choice untouched. |
 | Does the orchestrator ever do work itself? | Yes — quick reads, small bounded repository scans, decisions, root-cause exploration, trace-driven debugging, tightly coupled state work, and anything you explicitly asked *it* to judge. Other work is delegated when its combined cost, context, latency, isolation, or verification benefit exceeds reconstruction and integration overhead. |
-| My project has its own CLAUDE.md — conflict? | No file is ever touched: pilotfish writes only under `~/.claude/`. At runtime Claude Code *stacks* project memory and user memory — both load together, neither overrides the other. If one repo needs different behavior, add a local note there (e.g. "work inline in this repo, don't delegate") — the more specific instruction wins in practice. |
+| My project has its own CLAUDE.md — conflict? | No project file is ever touched: pilotfish writes only under the Claude Code configuration root (`~/.claude/` by default; `CLAUDE_CONFIG_DIR` overrides it). At runtime Claude Code *stacks* project memory and user memory — both load together, neither overrides the other. If one repo needs different behavior, add a local note there (e.g. "work inline in this repo, don't delegate") — the more specific instruction wins in practice. |
 | I also installed a delegation-planning skill | Treat it as a complementary planning layer. A skill such as [Baton](https://github.com/cablate/baton) can shape discovery questions, worker count, ownership, sequence, and stop conditions; pilotfish supplies the named Claude roles, model routing, leaf-agent boundary, approval gate, and verifier contract. The [compatibility Gates](./benchmarks/baton-compatibility/README.md) record the v1.3.2 envelope → current-slice → approved execution → `CONFIRMED` lifecycle, including an Opus 5 rerun whose disclosed post-verdict edit required a third corrective verification invocation. The [prompt-neutral activation Gate](./benchmarks/baton-dispatch-effect/README.md) separately covers four-scout dispatch under v1.3.1. These are bounded compatibility and reachability observations, not efficiency or frequency claims. pilotfish never disables user skills. |
 | Subagent quality worries me | `plan-verifier` reviews one envelope or slice before approval; outcome `verifier` independently tests the exact completed-work claim and returns `CONFIRMED`, `REFUTED`, or `INCONCLUSIVE`. Missing evidence stays inconclusive rather than becoming a false pass or speculative failure. `REVISE` still identifies the blocker, evidence, minimum revision, and acceptance check; two automatic Plan revisions remain the limit. Verification is not free, so small work skips it. |
 | Doesn't spawning agents cost extra? | Yes — every spawn is a fresh context that re-reads its slice of the codebase, and synthesis costs main-session tokens. A bounded task-local scan therefore stays inline by default. Discovery may still fan out when disjoint evidence materially reduces Plan uncertainty, while execution delegates only after its contract is stable. In the public mechanical control's execution-only segment, delegation reported 36.01% less cost with a 7.92% wall-time trade-off; neither compared run included the required outcome verifier, so this demonstrates route reachability rather than full-lifecycle savings. The research fixture shows the overhead of two scouts on one small task, not that plan-first discovery is categorically wrong. |
-| Turn it off fast? | **This session:** tell Claude "don't delegate this session — work inline"; it's just policy text, it obeys immediately. **This repo:** add a local note to the repo's CLAUDE.md. **Whole machine:** comment out the `pilotfish:begin/end` block in `~/.claude/CLAUDE.md` — the agent files just sit unused. No reinstall needed to switch back. |
+| Turn it off fast? | **This session:** tell Claude "don't delegate this session — work inline"; it's just policy text, it obeys immediately. **This repo:** add a local note to the repo's CLAUDE.md. **Whole machine:** comment out the `pilotfish:begin/end` block in the `CLAUDE.md` under the configuration root resolved by Step 0 of the [runbook](./install/AGENT-INSTALL.md) — the agent files just sit unused. No reinstall needed to switch back. |
 | Managed / enterprise machine? | Managed settings outrank user settings: a managed `model`, `availableModels` allowlist, or a managed agent with the same name will override pilotfish's user-level install. If roles don't take effect after restart, ask your admin — pilotfish can't (and shouldn't) override managed policy. |
 
 ## Research & design
@@ -265,9 +265,11 @@ map, exact-byte evidence rules, and pull request checklist.
 Tell Claude Code:
 
 ```text
-Uninstall pilotfish: remove the eight pilotfish agent files from ~/.claude/agents/,
-delete the <!-- pilotfish:begin --> ... <!-- pilotfish:end --> block from ~/.claude/CLAUDE.md,
-and offer to restore my previous "model" / remove "fallbackModel" in ~/.claude/settings.json.
+Read the local install/AGENT-INSTALL.md, resolve the Claude Code configuration
+root exactly as Step 0 specifies, and follow its Uninstall section. In that
+configuration root, remove the eight pilotfish agent files and policy block.
+Show me the full removal and settings-restoration plan and get my approval
+before writing.
 ```
 
 ## Support pilotfish

--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ Two subscription-specific bonuses stack on top:
 
 Three layers, three files' worth of configuration, all under `~/.claude/`:
 
+> **Configuration root:** these paths assume the default. If you set [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars), every `~/.claude/` path below lives under that directory instead, and the installer resolves it in Step 0 of the [runbook](./install/AGENT-INSTALL.md).
+
 > ⚠️ **Explicit Agent opt-in was required on one tested Claude Pro setup.**
 > On one first-party Pro account running Claude Code 2.1.220, a higher-priority
 > Agent tool contract blocked spawning unless the user explicitly requested
@@ -165,6 +167,8 @@ pilotfish installs by having Claude read a runbook and template files from this 
 - **Keep the approval gate:** Claude writes nothing until you approve the merge plan, but the plan is still a summary of the runbook. Review the local runbook and templates yourself, and do not weaken or bypass WebFetch's prompt-injection protection if the raw URL is intercepted.
 
 ## What gets installed
+
+> **Configuration root:** these paths assume the default. If you set [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars), every `~/.claude/` path below lives under that directory instead, and the installer resolves it in Step 0 of the [runbook](./install/AGENT-INSTALL.md).
 
 | Target | Change | Reversible |
 |---|---|---|

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -54,6 +54,8 @@ Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-o
 
 三層架構、三處設定，全部在 `~/.claude/` 底下：
 
+> **設定根目錄**：以下路徑是預設值。若你設了 [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars)，下列每個 `~/.claude/` 路徑都改在該目錄底下；[安裝 runbook](./install/AGENT-INSTALL.md) 會在 Step 0 解析它。
+
 > ⚠️ **一個已測試的 Claude Pro 環境需要明確 opt-in 才能委派 Agent。**
 > 在一個使用 Claude Code 2.1.220 的 first-party Pro 帳號上，較高優先級的
 > Agent tool contract 會阻止 spawn，除非使用者明確要求 agents。使用者層的
@@ -163,6 +165,8 @@ pilotfish 的安裝方式，是讓 Claude 從本 repo 讀取 runbook 與範本�
 - **保留 approval gate：** 經你同意前 Claude 不會動手，但計畫仍只是 runbook 的摘要。請自行審閱本地 runbook 與範本；若 raw URL 被攔截，也不要削弱或繞過 WebFetch 的 prompt-injection 防護。
 
 ## 安裝內容
+
+> **設定根目錄**：以下路徑是預設值。若你設了 [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars)，下列每個 `~/.claude/` 路徑都改在該目錄底下；[安裝 runbook](./install/AGENT-INSTALL.md) 會在 Step 0 解析它。
 
 | 目標 | 變更 | 可還原 |
 |---|---|---|

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -198,7 +198,7 @@ Read the local file install/AGENT-INSTALL.md in the current checkout and follow 
 
 | 想要…… | 做法 |
 |---|---|
-| 查目前安裝的版本 | `grep -o "pilotfish v[0-9.]*" ~/.claude/CLAUDE.md`——有標記但查不到版本＝v1.1.0 之前的安裝，建議更新 |
+| 查目前安裝的版本 | `CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; grep -o "pilotfish v[0-9.]*" "$CFG/CLAUDE.md"`——有標記但查不到版本＝v1.1.0 之前的安裝，建議更新 |
 | 收到新版通知 | 在 GitHub 對本 repo 按 **Watch → Custom → Releases** |
 | 看改了什麼 | [CHANGELOG.md](./CHANGELOG.md)——每個版本都有對應的 git tag |
 | 凍結在審核過的版本 | 用 tag 或 SHA 釘選安裝（見[信任與安全](#信任與安全)）——釘選的安裝在你重新釘選前不會變動 |
@@ -228,11 +228,11 @@ Read the local file install/AGENT-INSTALL.md in the current checkout and follow 
 | 主 session 用哪個 effort？ | 需要重判斷的 orchestration 先用 `high`；若額度或延遲更重要再往下降。若 opt-in Fable，請依它的模型專屬 prompting 指南調整。 |
 | 如何明確要求 1M context window？ | 純 `opus` alias 跟隨平台預設。若支援的平台上明確需要 1M，把 `model` 設為 `"opus[1m]"`；pilotfish 不會覆蓋既有選擇。 |
 | Orchestrator 自己完全不動手嗎？ | 會動手——馬上要用的閱讀、少量 repo 檔案掃描、決策、根因探索、trace-driven debugging，以及你明確要*它*判斷的事。其他工作只有在成本、context、時間、隔離或驗證的整體效益高於重建與整合成本時才委派。 |
-| 我的專案有自己的 CLAUDE.md，會衝突嗎？ | 檔案完全不會被動到：pilotfish 只寫 `~/.claude/` 底下。執行時 Claude Code 把專案層與使用者層記憶「疊加」載入——兩者同時生效、互不覆寫。若某個 repo 需要不同行為，在該專案的 CLAUDE.md 寫一條在地規則（例如「這個 repo 內直接動手、不委派」）——實務上較具體的指示會勝出。 |
+| 我的專案有自己的 CLAUDE.md，會衝突嗎？ | 專案檔案完全不會被動到：pilotfish 只寫 Claude Code 的設定根目錄（預設為 `~/.claude/`；`CLAUDE_CONFIG_DIR` 可覆寫）。執行時 Claude Code 把專案層與使用者層記憶「疊加」載入——兩者同時生效、互不覆寫。若某個 repo 需要不同行為，在該專案的 CLAUDE.md 寫一條在地規則（例如「這個 repo 內直接動手、不委派」）——實務上較具體的指示會勝出。 |
 | 我也裝了 delegation-planning skill | 請把它視為互補的規劃層。[Baton](https://github.com/cablate/baton) 這類 skill 可以塑造 discovery 問題、worker 數量、ownership、順序與 stop condition；pilotfish 提供具名 Claude 角色、模型分流、leaf-agent 邊界、approval gate 與 verifier contract。[相容性 Gates](./benchmarks/baton-compatibility/README.zh-TW.md) 記錄 v1.3.2 的 envelope → current slice → 批准執行 → `CONFIRMED` lifecycle，也包含因 post-verdict 編輯而必須用第三次 invocation 補驗的 Opus 5 rerun；[prompt-neutral 啟用 Gate](./benchmarks/baton-dispatch-effect/README.zh-TW.md) 另行覆蓋 v1.3.1 的四-scout dispatch。這些是有界的 compatibility 與 reachability 觀察，不代表效率或發生率。pilotfish 不會停用使用者 skills。 |
 | 擔心 subagent 品質 | `plan-verifier` 在批准前一次審一個 envelope 或 slice；outcome `verifier` 會獨立測試精確的 completed-work claim，並回覆 `CONFIRMED`、`REFUTED` 或 `INCONCLUSIVE`。缺少證據時維持 inconclusive，不會變成假通過或臆測失敗。`REVISE` 仍必須列 blocker、evidence、最小修訂與 acceptance check；Plan 同一 unit 自動修訂兩次後改由使用者決定。小型工作略過 verification。 |
 | Spawn agent 不是有額外成本嗎？ | 有——每次 spawn 都是全新 context、要重讀它負責的那部分 codebase，彙整也花 main session 的 token。因此有界的 task-local 掃描預設直接完成；若互相獨立的證據能實質降低 Plan 不確定性，discovery 仍可 fan-out，而 execution 要等 contract 穩定後才委派。公開機械式 control 的 execution-only 區段中，委派的 reported cost field 降低 36.01%，代價是 wall time 增加 7.92%；兩個比較 run 都沒有包含必要的 outcome verifier，因此只能證明便宜 route 可到達，不能宣稱完整 lifecycle savings。研究 fixture 只證明兩個 scout 在該小型任務上的 overhead，不代表 plan-first discovery 一律錯誤。 |
-| 怎麼快速關掉？ | **只關這個 session：** 直接跟 Claude 說「這個 session 不要委派，全部直接動手」——那只是政策文字，它立刻照辦。**只關這個 repo：** 在該 repo 的 CLAUDE.md 加一條在地規則。**整台機器：** 把 `~/.claude/CLAUDE.md` 裡的 `pilotfish:begin/end` 區塊註解掉——agent 檔留著閒置即可。切回來不必重裝。 |
+| 怎麼快速關掉？ | **只關這個 session：** 直接跟 Claude 說「這個 session 不要委派，全部直接動手」——那只是政策文字，它立刻照辦。**只關這個 repo：** 在該 repo 的 CLAUDE.md 加一條在地規則。**整台機器：** 把[安裝 runbook](./install/AGENT-INSTALL.md) Step 0 解析出的設定根目錄中，`CLAUDE.md` 裡的 `pilotfish:begin/end` 區塊註解掉——agent 檔留著閒置即可。切回來不必重裝。 |
 | 公司管的機器（managed）？ | Managed settings 優先於使用者層設定：managed 的 `model`、`availableModels` 白名單、或同名的 managed agent 都會蓋過 pilotfish 的使用者層安裝。重啟後角色沒生效就找管理員——pilotfish 設計上不會（也不該）繞過管理政策。 |
 
 ## 研究與設計
@@ -263,9 +263,11 @@ Read the local file install/AGENT-INSTALL.md in the current checkout and follow 
 告訴 Claude Code：
 
 ```text
-Uninstall pilotfish: remove the eight pilotfish agent files from ~/.claude/agents/,
-delete the <!-- pilotfish:begin --> ... <!-- pilotfish:end --> block from ~/.claude/CLAUDE.md,
-and offer to restore my previous "model" / remove "fallbackModel" in ~/.claude/settings.json.
+Read the local install/AGENT-INSTALL.md, resolve the Claude Code configuration
+root exactly as Step 0 specifies, and follow its Uninstall section. In that
+configuration root, remove the eight pilotfish agent files and policy block.
+Show me the full removal and settings-restoration plan and get my approval
+before writing.
 ```
 
 ## 支持 pilotfish

--- a/install/AGENT-INSTALL.md
+++ b/install/AGENT-INSTALL.md
@@ -25,7 +25,7 @@ Claude Code reads global configuration from `~/.claude/` **only when `CLAUDE_CON
 > `CLAUDE_CONFIG_DIR` — Override the configuration directory (default: `~/.claude`). All settings, session history, and plugins are stored under this path […]
 > — [Claude Code environment variables](https://code.claude.com/docs/en/env-vars)
 
-Resolve it before reading or writing anything, and use the printed absolute path as `$CFG` for the rest of this runbook:
+Resolve it before reading or writing anything, and use the printed path verbatim as `$CFG` for the rest of this runbook:
 
 ```bash
 echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
@@ -33,7 +33,11 @@ echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
 
 > ⚠️ **Do not assume `~/.claude`.** On a machine where `CLAUDE_CONFIG_DIR` points elsewhere, installing into `~/.claude/` *creates* that directory, passes every check in Step 4, and installs nothing Claude Code will ever load — a silent no-op with no error to explain it. The same mistake makes an upgrade look like a fresh install (no markers found in the decoy directory) and makes an uninstall delete the decoy while leaving the real install in place.
 
-Carry the resolved path into the Step 2 plan so the user can catch a wrong root before anything is written. If the variable is set to a relative or `~`-prefixed value, expand it to an absolute path first.
+Carry the resolved path into the Step 2 plan so the user can catch a wrong root before anything is written.
+
+> ⚠️ **Do not normalize the value.** Claude Code does not expand a leading `~` inside `CLAUDE_CONFIG_DIR`, and it resolves a relative value against the current working directory. Observed on 2.1.220: with `CLAUDE_CONFIG_DIR='~/.claude-probe'` it creates a directory named literally `~` under the cwd, and with `CLAUDE_CONFIG_DIR='.claude-probe'` it uses `$PWD/.claude-probe`. Rewriting either value into `$HOME/...` installs into a directory Claude Code never reads — the exact failure this step exists to prevent. Use the value as Claude Code sees it.
+
+If the resolved root is not absolute, **stop and tell the user** their `CLAUDE_CONFIG_DIR` is almost certainly misconfigured: a relative root moves with whatever directory the shell happens to be in, so their configuration is already split across every cwd they have launched `claude` from. Let them fix the variable; do not guess an absolute path on their behalf.
 
 ## Updating an existing install
 

--- a/install/AGENT-INSTALL.md
+++ b/install/AGENT-INSTALL.md
@@ -4,13 +4,13 @@
 
 ## What you are installing
 
-pilotfish is a global multi-model orchestration layer for Claude Code. It touches exactly three places, all under `~/.claude/`:
+pilotfish is a global multi-model orchestration layer for Claude Code. It touches exactly three places, all under the Claude Code configuration root — written `$CFG` throughout this runbook and resolved in [Step 0](#step-0--resolve-the-configuration-root):
 
 | Target | Change |
 |---|---|
-| `~/.claude/settings.json` | Set `model` to `"opus"`, add `fallbackModel`, conditionally extend `availableModels` |
-| `~/.claude/agents/` | Install eight role agent files: `scout.md`, `Explore.md`, `plan-verifier.md`, `security-reviewer.md`, `mech-executor.md`, `executor.md`, `verifier.md`, `security-executor.md` |
-| `~/.claude/CLAUDE.md` | Insert one `## Orchestration` section between `<!-- pilotfish:begin -->` and `<!-- pilotfish:end -->` markers |
+| `$CFG/settings.json` | Set `model` to `"opus"`, add `fallbackModel`, conditionally extend `availableModels` |
+| `$CFG/agents/` | Install eight role agent files: `scout.md`, `Explore.md`, `plan-verifier.md`, `security-reviewer.md`, `mech-executor.md`, `executor.md`, `verifier.md`, `security-executor.md` |
+| `$CFG/CLAUDE.md` | Insert one `## Orchestration` section between `<!-- pilotfish:begin -->` and `<!-- pilotfish:end -->` markers |
 
 Source of truth for the files: the [templates/](../templates/) directory of this repository. If you are running inside a local clone, use those files directly; otherwise fetch each from `https://raw.githubusercontent.com/Nanako0129/pilotfish/main/templates/...`.
 
@@ -18,11 +18,28 @@ Source of truth for the files: the [templates/](../templates/) directory of this
 
 > **Portability:** Prefer your own Read / Write / Edit tools over shell commands for all file operations — they behave identically on macOS, Linux, WSL, and native Windows. The bash snippets below are references, not requirements: on native Windows (PowerShell, no Git Bash) they will not run — create directories and copy backups with your file tools, count markers by reading the file, and if `jq` is unavailable validate JSON by parsing it yourself.
 
+## Step 0 — Resolve the configuration root
+
+Claude Code reads global configuration from `~/.claude/` **only when `CLAUDE_CONFIG_DIR` is unset**. When that variable is set, every path in this runbook lives under it instead:
+
+> `CLAUDE_CONFIG_DIR` — Override the configuration directory (default: `~/.claude`). All settings, session history, and plugins are stored under this path […]
+> — [Claude Code environment variables](https://code.claude.com/docs/en/env-vars)
+
+Resolve it before reading or writing anything, and use the printed absolute path as `$CFG` for the rest of this runbook:
+
+```bash
+echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"
+```
+
+> ⚠️ **Do not assume `~/.claude`.** On a machine where `CLAUDE_CONFIG_DIR` points elsewhere, installing into `~/.claude/` *creates* that directory, passes every check in Step 4, and installs nothing Claude Code will ever load — a silent no-op with no error to explain it. The same mistake makes an upgrade look like a fresh install (no markers found in the decoy directory) and makes an uninstall delete the decoy while leaving the real install in place.
+
+Carry the resolved path into the Step 2 plan so the user can catch a wrong root before anything is written. If the variable is set to a relative or `~`-prefixed value, expand it to an absolute path first.
+
 ## Updating an existing install
 
 When the user asks to **update** (rather than fresh-install), run this before Step 1:
 
-1. Detect the installed version: search `~/.claude/CLAUDE.md` for `pilotfish v` inside the marker block. A version comment like `<!-- pilotfish v1.1.0 -->` gives the installed version; **markers present but no version comment means a pre-v1.1.0 install** (update recommended).
+1. Detect the installed version: search `$CFG/CLAUDE.md` for `pilotfish v` inside the marker block. A version comment like `<!-- pilotfish v1.1.0 -->` gives the installed version; **markers present but no version comment means a pre-v1.1.0 install** (update recommended).
 2. Fetch the latest version and changelog from the same ref you were invoked from (`VERSION` and `CHANGELOG.md` at the repo root — e.g. `https://raw.githubusercontent.com/Nanako0129/pilotfish/main/VERSION`).
 3. If already up to date, say so and stop. Otherwise show the user the changelog entries between their version and the latest, then proceed with Steps 1–4 below — the install is idempotent, so an update is just a re-run: unchanged files are skipped, the policy block is replaced in place, and settings keys are only touched if missing.
 4. If the user customized any agent file, the Step 3.3 diff will surface it — never overwrite a customization without showing the diff and asking.
@@ -32,31 +49,32 @@ When the user asks to **update** (rather than fresh-install), run this before St
 Gather the current state before proposing anything:
 
 1. Run `claude --version` and parse its semantic version. pilotfish requires **Claude Code 2.1.219 or newer** as its tested floor for Opus 5-aware alias routing; this is also newer than the verified baseline that enforces agent `tools` allowlists. The version floor does not guarantee one exact backend for every provider, account, or settings stack. If the command is unavailable, its version cannot be parsed, or it reports an older version, **stop before presenting a write plan or changing anything** and ask the user to update Claude Code. Do not install a prompt-only approximation: `plan-verifier` and `security-reviewer` depend on enforced tool exclusion to preserve the pre-approval read-only boundary.
-2. Read `~/.claude/settings.json` (note the current `model`, and whether `fallbackModel` / `availableModels` exist). If the file is missing, you will create a minimal one.
-3. Read `~/.claude/CLAUDE.md` if it exists. Check for existing `<!-- pilotfish:begin -->` / `<!-- pilotfish:end -->` markers — their presence means this is an **upgrade**, not a fresh install.
-4. List `~/.claude/agents/` and note which of the eight pilotfish filenames already exist. **Also read the `name:` frontmatter of every existing agent file (any filename)** — Claude Code resolves collisions by the `name` field, not the filename, and loads only one definition per name. If any existing agent already declares `name: scout`, `Explore`, `plan-verifier`, `security-reviewer`, `mech-executor`, `executor`, `verifier`, or `security-executor`, flag it as a name collision in the plan and ask the user whether to rename theirs, skip that pilotfish role, or overwrite. Likewise note any enabled **plugin** that ships agents with these names — a user-level file shadows the plugin's version (still reachable via its scoped `plugin:name`).
+2. Read `$CFG/settings.json` (note the current `model`, and whether `fallbackModel` / `availableModels` exist). If the file is missing, you will create a minimal one.
+3. Read `$CFG/CLAUDE.md` if it exists. Check for existing `<!-- pilotfish:begin -->` / `<!-- pilotfish:end -->` markers — their presence means this is an **upgrade**, not a fresh install.
+4. List `$CFG/agents/` and note which of the eight pilotfish filenames already exist. **Also read the `name:` frontmatter of every existing agent file (any filename)** — Claude Code resolves collisions by the `name` field, not the filename, and loads only one definition per name. If any existing agent already declares `name: scout`, `Explore`, `plan-verifier`, `security-reviewer`, `mech-executor`, `executor`, `verifier`, or `security-executor`, flag it as a name collision in the plan and ask the user whether to rename theirs, skip that pilotfish role, or overwrite. Likewise note any enabled **plugin** that ships agents with these names — a user-level file shadows the plugin's version (still reachable via its scoped `plugin:name`).
 5. Check whether the environment variable `CLAUDE_CODE_SUBAGENT_MODEL` is set (`echo "$CLAUDE_CODE_SUBAGENT_MODEL"`).
 
 > ⚠️ **Warning:** If `CLAUDE_CODE_SUBAGENT_MODEL` is set, it silently overrides every per-agent `model` frontmatter and defeats the entire tiering design. Flag it in your plan and recommend unsetting it. Do not unset it yourself without approval.
 
 ## Step 2 — Present the plan and get approval
 
-Show the user a table of every change you intend to make: each file, the exact modification, and whether it is a create / merge / replace-between-markers / skip. Include a backup line (Step 3.1). **Do not write anything until the user approves.**
+State the resolved `$CFG` from Step 0 above the table, then show the user a table of every change you intend to make: each file, the exact modification, and whether it is a create / merge / replace-between-markers / skip. Include a backup line (Step 3.1). **Do not write anything until the user approves.**
 
 ## Step 3 — Apply
 
 ### 3.1 Backup and directories
 
 ```bash
-mkdir -p ~/.claude/backups ~/.claude/agents
+CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"   # Step 0
+mkdir -p "$CFG/backups" "$CFG/agents"
 # settings backup: FIRST install only — the pristine pre-pilotfish state must be preserved
-ls ~/.claude/backups/settings.json.pilotfish-* >/dev/null 2>&1 || \
-  cp ~/.claude/settings.json ~/.claude/backups/settings.json.pilotfish-$(date +%Y%m%d-%H%M%S) 2>/dev/null || true
+ls "$CFG"/backups/settings.json.pilotfish-* >/dev/null 2>&1 || \
+  cp "$CFG/settings.json" "$CFG/backups/settings.json.pilotfish-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || true
 # CLAUDE.md backup: every run
-cp ~/.claude/CLAUDE.md ~/.claude/backups/CLAUDE.md.pilotfish-$(date +%Y%m%d-%H%M%S) 2>/dev/null || true
+cp "$CFG/CLAUDE.md" "$CFG/backups/CLAUDE.md.pilotfish-$(date +%Y%m%d-%H%M%S)" 2>/dev/null || true
 ```
 
-> **Note:** If `~/.claude/settings.json` did not exist before this install (fresh machine), there is no settings backup — record in your final summary that the pre-install state had **no `model` key**, so a future uninstall knows to *remove* the key rather than restore a value.
+> **Note:** If `$CFG/settings.json` did not exist before this install (fresh machine), there is no settings backup — record in your final summary that the pre-install state had **no `model` key**, so a future uninstall knows to *remove* the key rather than restore a value.
 
 ### 3.2 settings.json — merge, key by key
 
@@ -68,13 +86,13 @@ Never rewrite the whole file; edit only these keys and preserve everything else:
 | `fallbackModel` | If absent → add `["sonnet"]` (handles primary-model overload/unavailability). If present → leave it and note it in the summary. |
 | `availableModels` | **Only if the key already exists** (it is an allowlist): ensure it contains `"opus"`, `"fable"`, `"sonnet"`, `"haiku"`, and the chosen main-model value — append whatever is missing. This keeps the documented `/model fable` opt-in reachable. If the key is absent → do not add it (absent = unrestricted, which is fine). |
 
-Validate afterwards: `jq empty ~/.claude/settings.json`.
+Validate afterwards: `jq empty "$CFG/settings.json"`.
 
 > **Note:** `opus` is a family alias, not a full model pin; it follows the provider's current Opus version. Users can opt into Fable 5 with `/model fable`, or choose `"opus[1m]"` when they explicitly need the documented 1M alias. pilotfish does not replace those choices on later installs without approval.
 
 ### 3.3 Agent files
 
-For each of the eight files in `templates/agents/`, write it to `~/.claude/agents/<same-name>.md`:
+For each of the eight files in `templates/agents/`, write it to `$CFG/agents/<same-name>.md`:
 
 | Existing state | Action |
 |---|---|
@@ -89,7 +107,7 @@ For each of the eight files in `templates/agents/`, write it to `~/.claude/agent
 
 The canonical section content is [templates/claude-md.orchestration.md](../templates/claude-md.orchestration.md) — it already includes the begin/end markers.
 
-Before writing, count the markers: `grep -c "pilotfish:begin" ~/.claude/CLAUDE.md`. The count must be `0` (fresh) or `1` (upgrade).
+Before writing, count the markers: `grep -c "pilotfish:begin" "$CFG/CLAUDE.md"`. The count must be `0` (fresh) or `1` (upgrade).
 
 | Marker count | Action |
 |---|---|
@@ -102,17 +120,18 @@ Do not modify anything outside the markers.
 
 ## Step 4 — Verify and hand off
 
-1. `jq empty ~/.claude/settings.json` exits 0.
-2. `ls ~/.claude/agents/` shows all eight files.
-3. The markers appear exactly once in `~/.claude/CLAUDE.md`: `grep -c "pilotfish:begin" ~/.claude/CLAUDE.md` prints `1`.
-4. Read the installed policy block and verify that it says existing named roles are invoked without `model`, while only truly ad-hoc agents with no named role definition receive an explicit invocation model.
-5. Tell the user to **restart their Claude Code session**: the agents directory is scanned at session start, and the `model` setting applies on restart. After restart, `/model` should show the new default, and asking Claude "which subagent types are available?" should list the eight roles (scout, Explore, plan-verifier, security-reviewer, mech-executor, executor, verifier, security-executor). On Claude Code before 2.1.198 you can also run `/agents` to see them; that wizard was removed in 2.1.198.
-6. Summarize what changed, what was skipped, and where the backups are.
+1. Every path you wrote is under the `$CFG` resolved in Step 0. Re-run `echo "${CLAUDE_CONFIG_DIR:-$HOME/.claude}"` and compare it against your Step 2 plan. The three checks below cannot catch a wrong root: they inspect whichever directory you just wrote to, so they pass either way.
+2. `jq empty "$CFG/settings.json"` exits 0.
+3. `ls "$CFG/agents/"` shows all eight files.
+4. The markers appear exactly once in `$CFG/CLAUDE.md`: `grep -c "pilotfish:begin" "$CFG/CLAUDE.md"` prints `1`.
+5. Read the installed policy block and verify that it says existing named roles are invoked without `model`, while only truly ad-hoc agents with no named role definition receive an explicit invocation model.
+6. Tell the user to **restart their Claude Code session**: the agents directory is scanned at session start, and the `model` setting applies on restart. After restart, `/model` should show the new default, and asking Claude "which subagent types are available?" should list the eight roles (scout, Explore, plan-verifier, security-reviewer, mech-executor, executor, verifier, security-executor). On Claude Code before 2.1.198 you can also run `/agents` to see them; that wizard was removed in 2.1.198.
+7. Summarize what changed, what was skipped, and where the backups are.
 
 ## Uninstall
 
 On request, reverse the three targets:
 
-1. Delete the eight files from `~/.claude/agents/` (only ones whose content matches pilotfish templates — show a diff first if they were customized).
-2. Remove the block from `<!-- pilotfish:begin -->` through `<!-- pilotfish:end -->` (inclusive) in `~/.claude/CLAUDE.md`; delete the file only if that leaves it empty and the user confirms.
-3. In `~/.claude/settings.json`: restore `model` from the **oldest** `settings.json.pilotfish-*` backup in `~/.claude/backups/` — that file is the pre-install state (Step 3.1 only ever backs up settings once, on first install). If no such backup exists, or the backup has no `model` key, **remove** the `model` key instead of leaving the pilotfish value. Remove `fallbackModel` if the user doesn't want it. Leave `availableModels` additions in place unless asked — they are harmless.
+1. Delete the eight files from `$CFG/agents/` (only ones whose content matches pilotfish templates — show a diff first if they were customized).
+2. Remove the block from `<!-- pilotfish:begin -->` through `<!-- pilotfish:end -->` (inclusive) in `$CFG/CLAUDE.md`; delete the file only if that leaves it empty and the user confirms.
+3. In `$CFG/settings.json`: restore `model` from the **oldest** `settings.json.pilotfish-*` backup in `$CFG/backups/` — that file is the pre-install state (Step 3.1 only ever backs up settings once, on first install). If no such backup exists, or the backup has no `model` key, **remove** the `model` key instead of leaving the pilotfish value. Remove `fallbackModel` if the user doesn't want it. Leave `availableModels` additions in place unless asked — they are harmless.


### PR DESCRIPTION
Closes #36.

### Problem

`install/AGENT-INSTALL.md` addressed the configuration root as the literal path `~/.claude/` in 22 places and never read `CLAUDE_CONFIG_DIR`. On a machine where that variable is set, the installing agent writes all three targets to a directory Claude Code never reads, and nothing about the run signals it: Step 3.1's `mkdir -p` creates the directory, and each Step 4 check inspects whichever directory the agent just populated, so all of them pass with nothing installed.

### What this changes

**New Step 0 — Resolve the configuration root.** Resolves `${CLAUDE_CONFIG_DIR:-$HOME/.claude}` once, names the result `$CFG`, quotes the upstream documentation for the variable, and states the failure mode explicitly so an agent reading the runbook cannot treat `~/.claude` as a safe default. Placed before "Updating an existing install" so every later step, including version detection, resolves against it. Existing Step 1–4 numbering is untouched.

**All 22 path references rewritten against `$CFG`.** The bash snippets now open with `CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"` and quote the expansions, so a config root containing spaces also works.

**Step 2 states the resolved root above the approval table**, which puts a wrong root in front of the user while the write plan is still reversible.

**Step 4 leads with a root check** and says why the three checks after it cannot catch this failure: they inspect whatever directory was just written. Without that sentence the verification list reads as sufficient, which is how the original silently passed.

**Both READMEs** get one note where they describe the three install targets. Their example paths stay literal, matching how the official docs present `~/.claude` with a resolution rule alongside it rather than substituting a variable into every line.

### Scope

Documentation only. No changes to `templates/`, so the installed policy block, the eight role payloads, and every recorded hash and Gate snapshot are unaffected.

Not touched, deliberately:

- `benchmarks/**` and `CHANGELOG.md` — historical records
- `docs/design.md`, `docs/research*.md`, `RELEASING.md` — narrative and maintainer docs that describe the default layout rather than driving an install

One pre-existing off-by-one is also left alone to keep this diff single-purpose: §3.3 and §1.3 cite "Step 1.3" for the agent-name collision check, which is item 4 of Step 1.

### Verification

- `rg -c '~/\.claude' install/AGENT-INSTALL.md` → 4, all inside Step 0 where the literal path is the subject of the sentence
- Runbook reviewed end to end for stale cross-references after the Step 4 renumbering (items 4–6 became 5–7)
- The zh-TW note was checked for Taiwanese-Mandarin orthography and punctuation

Reported from a real install: `CLAUDE_CONFIG_DIR=~/.config/claude` on macOS with no `~/.claude` present, Claude Code 2.1.220. Before this change, following the runbook as written installs into a directory that has no effect; the reproduction is in #36.
