### PR TITLE
docs(readme): document the two Agent-suppression injections and their claim boundaries

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,36 @@ Three layers, three files' worth of configuration, all under `~/.claude/`:
 > attributed to prompt compression. Tracking:
 > [#29](https://github.com/Nanako0129/pilotfish/issues/29).
 
+<details>
+<summary><b>What the mechanism is</b> — two independent injections, and what we can and cannot claim about them</summary>
+
+Two different injections have been discussed as if they were one. Both were read out of official Claude Code builds under `~/.local/share/claude/versions/`, and every claim here is anchored to a string you can search for yourself rather than to a byte offset.
+
+| | this repo's report | the other one |
+|---|---|---|
+| site | Agent tool description | system prompt section, flag name `tengu_heron_brook` |
+| text | `Do not spawn agents unless the user asks.` … `it's the expensive path on this plan.` | `Do not call the AgentTool unless the user requested it` |
+| gate | a subscription-type comparison against `"pro"`, inline in the tool-description builder, with no override in that expression | resolver `dMy`, three ordered sources — see below |
+| tracked in | [#29](https://github.com/Nanako0129/pilotfish/issues/29) | [Serhii-Leniv/claude-router#55](https://github.com/Serhii-Leniv/claude-router/issues/55), [anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988) |
+
+The second one is a **string-valued** section, not a boolean one. In 2.1.220, `dMy` resolves its content from client data, then a flag lookup, then a built-in default; the first two sources can supply arbitrary text. The `opus_5_prompt_bundle` capability check and its killswitch live in `tXn`, which gates **only** the built-in-default branch.
+
+Three separate string searches across the official builds we retain:
+
+| official build | tool-description paragraph | `tengu_heron_brook` identifier | built-in default payload |
+|---|---|---|---|
+| 2.1.218 | present | present (7×) | absent |
+| 2.1.219 | present | present | present |
+| 2.1.220 | present | present | present |
+
+**Claim boundary.** A string present in a binary is not an instruction active in a session, and three builds cannot establish when anything was introduced upstream — [anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988) is the source for that side of it. We found no documented user-facing setting that opts in persistently, and we do not claim none exists; that needs CLI and settings evidence we have not gathered. As corroboration only, from our own repackaging of Claude Code native builds, [Calico](https://github.com/Nanako0129/calico-claude): the tool-description paragraph is present there in 2.1.207 through 2.1.220.
+
+**Cheapest check available.** Ask a fresh session what its delegation policy is. In the session where we looked, the paragraph was present in the Agent tool description and the session could quote its own constraint — no patched build, no proxy, no transcript analysis needed.
+
+**If you also run [claude-router](https://github.com/Serhii-Leniv/claude-router):** do not enable `forceRoute` while pilotfish is installed. It overrides the model each agent sets in its own frontmatter, which is exactly how pilotfish gives `verifier` a fresh Opus context; an Opus-pinned role was observed running on `claude-sonnet-5`. That tool's `restoreDelegation` option strips the second injection above.
+
+</details>
+
 | Layer | File(s) | Job |
 |---|---|---|
 | Machine | `~/.claude/settings.json` | Who orchestrates (`opus`) + automatic `fallbackModel` chain |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -68,6 +68,36 @@ Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-o
 > prompt compression。追蹤：
 > [#29](https://github.com/Nanako0129/pilotfish/issues/29)。
 
+<details>
+<summary><b>機制是什麼</b>——兩個各自獨立的注入，以及哪些能主張、哪些不能</summary>
+
+先前被當成同一件事討論的，其實是兩個不同的注入。兩者都是從 `~/.local/share/claude/versions/` 底下的官方 Claude Code build 讀出來的；以下每一項主張都錨定在你可以自己搜尋的字串，而不是 byte offset。
+
+| | 本 repo 追蹤的那個 | 另一個 |
+|---|---|---|
+| 位置 | Agent tool description | system prompt 區段，flag 名稱 `tengu_heron_brook` |
+| 文字 | `Do not spawn agents unless the user asks.` … `it's the expensive path on this plan.` | `Do not call the AgentTool unless the user requested it` |
+| gate | 在 tool-description builder 內就地比對訂閱方案是否為 `"pro"`，該運算式本身沒有任何 override | resolver `dMy`，三個依序來源——見下 |
+| 追蹤於 | [#29](https://github.com/Nanako0129/pilotfish/issues/29) | [Serhii-Leniv/claude-router#55](https://github.com/Serhii-Leniv/claude-router/issues/55)、[anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988) |
+
+第二個是**字串值**的區段，不是布林值。在 2.1.220 中，`dMy` 依序從 client data、flag 查詢、內建預設值解析內容；前兩個來源可以塞任意文字。`opus_5_prompt_bundle` capability 檢查與它的 killswitch 位在 `tXn`，而 `tXn` **只**管內建預設值那一支。
+
+在我們留存的官方 build 上做三次獨立的字串搜尋：
+
+| 官方 build | tool-description 段落 | `tengu_heron_brook` 識別字 | 內建預設 payload |
+|---|---|---|---|
+| 2.1.218 | present | present（7 次） | absent |
+| 2.1.219 | present | present | present |
+| 2.1.220 | present | present | present |
+
+**主張邊界。** 字串存在於 binary 不等於該指令在 session 中生效；三個 build 也無法證明上游何時引入某項東西——那一側的來源是 [anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988)。我們沒有找到任何有文件的使用者層設定可以持久 opt-in，但也不主張這種設定不存在；那需要我們尚未蒐集的 CLI 與 settings 證據。以下僅作為佐證，來自我們自己重新封裝的 Claude Code 原生 build [Calico](https://github.com/Nanako0129/calico-claude)：tool-description 段落在其 2.1.207 到 2.1.220 都存在。
+
+**最省力的檢查方式。** 開一個新 session，問它自己的委派政策。在我們檢查的那個 session 裡，該段落存在於 Agent tool description，而 session 被問到時能引用自己的限制——不需要 patch 過的 build、不需要 proxy、不需要分析 transcript。
+
+**如果你同時使用 [claude-router](https://github.com/Serhii-Leniv/claude-router)：** 裝了 pilotfish 就不要開 `forceRoute`。它會覆蓋每個 agent 在自己 frontmatter 設定的模型，而那正是 pilotfish 讓 `verifier` 拿到全新 Opus context 的方式；已有實測觀察到一個釘在 Opus 的角色跑在 `claude-sonnet-5` 上。該工具的 `restoreDelegation` 選項則會剝除上面第二個注入。
+
+</details>
+
 | 層 | 檔案 | 職責 |
 |---|---|---|
 | 機器層 | `~/.claude/settings.json` | 決定誰當 orchestrator（`opus`）＋自動 `fallbackModel` 切換鏈 |


### PR DESCRIPTION
Both READMEs carried the symptom of #29 — a Claude Pro session completing eligible work inline with zero Agent calls, plus the explicit-request workaround — without stating the mechanism, and the single warning blockquote conflated two unrelated injections that had been discussed as one.

## What this adds

A collapsed `<details>` section immediately after the existing warning in both READMEs. The existing blockquote is untouched, so the diff is purely additive.

| | tracked here | tracked upstream |
|---|---|---|
| site | Agent tool description | system prompt section, flag name `tengu_heron_brook` |
| gate | inline subscription-type comparison against `"pro"`, no override in that expression | resolver `dMy`: client data → flag lookup → built-in default |
| capability check | — | `opus_5_prompt_bundle` and its killswitch live in `tXn`, gating only the built-in-default branch |
| references | #29 | Serhii-Leniv/claude-router#55, anthropics/claude-code#80988 |

The second injection is string-valued rather than boolean — the first two sources can supply arbitrary text. A three-column table reports three distinct string searches over the official builds retained locally; splitting them matters, because 2.1.218 carries the identifier seven times with no payload, so the section machinery predates the default text arriving in 2.1.219.

## Claim discipline

Tightened over an earlier draft of this material, after an independent review found the earlier version had attributed the gate to the wrong helper:

- claims anchored to searchable strings, not byte offsets, since the identifiers are minified
- string present in a binary is stated as distinct from an instruction active in a session
- three retained builds explicitly cannot establish upstream introduction; #80988 cited for that
- no supported-interface conclusion — no documented user-facing opt-in was found, and the text declines to claim none exists
- [Calico](https://github.com/Nanako0129/calico-claude), this project's own repackaging of Claude Code builds, demoted to a corroboration sentence with its repo linked, and no longer described as display-only

Also documents the interaction confirmed by both claude-router's maintainer and #29's reporter: `forceRoute` overrides the model each agent pins in its frontmatter, which is how `verifier` gets a fresh Opus context; an Opus-pinned role was observed on `claude-sonnet-5`.

## Verification

- `python3 -m unittest discover -s tests` → 33 tests, OK
- the five README substrings asserted at `tests/test_policy.py:849-851` and `:991-996` present in both files
- both files checked for the nine content strings the new section must carry
- `git diff --check` clean
- no `templates/**` change, so no policy contract test or gate snapshot hash is affected, and no VERSION or CHANGELOG stamp moves

## Not in scope

No benchmark is run and no dispatch-rate claim is made or changed. The remaining Gate work keeping #29 open, and the separate template-size regression against #27, are tracked separately.

Refs #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGMQdjkoh8CCsRwm1Mi5fG
