### PR TITLE
test(spontaneous-dispatch): baseline the shipped policy on Max, and rescope the delegation warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,15 +63,17 @@ Three layers, three files' worth of configuration, all under `~/.claude/`:
 > attempts dispatched nothing. On the same machine and client after an upgrade to
 > Max, a four-cell baseline reached the expected topology on **one positive attempt
 > out of four** — the twelve-file mechanical cell failed both attempts with the main
-> session rewriting every file itself. Better than Pro, nowhere near reliable. There
-> are two separate injections with different gates; the subscription-gated one was
-> observed absent on Max while the session-guidance one remained. Both plans are
-> affected, differently.
+> session rewriting every file itself. Dispatch was observed on Max and not on Pro,
+> but the two are not a ranking: the cells differ, the repository tree changed
+> alongside the plan, and a handful of attempts is not a rate. There are two separate
+> injections with different gates; the subscription-gated one was observed absent on
+> Max while the session-guidance one remained. Neither plan reliably dispatches.
 > When you want the orchestration lifecycle, add
 > `Use pilotfish and delegate eligible work to the named agents.` to the request.
 > Explicit direction reached the exercised `scout`, `plan-verifier`,
-> `mech-executor`, and `verifier` paths on both plans tested; other roles were not
-> tested. This is not attributed to prompt compression: the unchanged v1.3.3
+> `mech-executor`, and `verifier` paths on the Pro account, which is the only plan
+> where the explicit arm was run; other roles, and explicit direction on Max, were
+> not tested. This is not attributed to prompt compression: the unchanged v1.3.3
 > cue-free control recorded zero dispatch alongside the v1.3.4 compressed
 > candidate. Per-cell evidence, including what "cue-free" does and does not mean
 > in those records, is in

--- a/README.md
+++ b/README.md
@@ -56,19 +56,27 @@ Three layers, three files' worth of configuration, all under `~/.claude/`:
 
 > **Configuration root:** these paths assume the default. If you set [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars), every `~/.claude/` path below lives under that directory instead, and the installer resolves it in Step 0 of the [runbook](./install/AGENT-INSTALL.md).
 
-> ⚠️ **Explicit Agent opt-in was required on one tested Claude Pro setup.**
-> On one first-party Pro account running Claude Code 2.1.220, a higher-priority
-> Agent tool contract blocked spawning unless the user explicitly requested
-> agents. A user-level `CLAUDE.md` could not override that session contract, so
-> a successful pilotfish install does not guarantee cue-free delegation in every
-> environment. Add
-> `Use pilotfish and delegate eligible work to the named agents.` to the request
-> when you want the orchestration lifecycle. Explicit direction reached the
-> exercised `scout`, `plan-verifier`, `mech-executor`, and `verifier` paths;
-> other roles were not tested. Both the v1.3.4 compressed candidate and unchanged
-> v1.3.3 cue-free control recorded zero dispatch, so this observation is not
-> attributed to prompt compression. Tracking:
-> [#29](https://github.com/Nanako0129/pilotfish/issues/29).
+> ⚠️ **A successful install does not guarantee automatic delegation. Add an explicit opt-in when you need the lifecycle.**
+> Higher-priority Claude Code instructions can suppress Agent dispatch, and a
+> user-level `CLAUDE.md` cannot override them. This is not confined to one plan.
+> On a first-party Pro account running Claude Code 2.1.220, two cue-free schema
+> attempts dispatched nothing. On the same machine and client after an upgrade to
+> Max, a four-cell baseline reached the expected topology on **one positive attempt
+> out of four** — the twelve-file mechanical cell failed both attempts with the main
+> session rewriting every file itself. Better than Pro, nowhere near reliable. There
+> are two separate injections with different gates; the subscription-gated one was
+> observed absent on Max while the session-guidance one remained. Both plans are
+> affected, differently.
+> When you want the orchestration lifecycle, add
+> `Use pilotfish and delegate eligible work to the named agents.` to the request.
+> Explicit direction reached the exercised `scout`, `plan-verifier`,
+> `mech-executor`, and `verifier` paths on both plans tested; other roles were not
+> tested. This is not attributed to prompt compression: the unchanged v1.3.3
+> cue-free control recorded zero dispatch alongside the v1.3.4 compressed
+> candidate. Per-cell evidence, including what "cue-free" does and does not mean
+> in those records, is in
+> [`benchmarks/spontaneous-dispatch`](./benchmarks/spontaneous-dispatch/README.md).
+> Tracking: [#29](https://github.com/Nanako0129/pilotfish/issues/29).
 
 <details>
 <summary><b>What the mechanism is</b> — two independent injections, and what we can and cannot claim about them</summary>

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -62,12 +62,14 @@ Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-o
 > first-party Pro 帳號上，兩次 cue-free schema attempt 都沒有委派；同一台機器、
 > 同一個 client 升級 Max 之後，一組四格 baseline **四次正向嘗試只有一次**達到預期
 > 拓撲——十二檔案的 mechanical 那格兩次全失敗，主 session 自己改完全部檔案。
-> 比 Pro 好，但遠談不上可靠。有兩個各自獨立、gate 不同的注入：訂閱層級那個在
-> Max 上實測消失，session guidance 那個仍在。**兩種方案都受影響，只是方式不同。**
+> Max 上觀察到委派、Pro 上沒有，但這兩者不構成排序：測試格不同、repository 樹
+> 隨方案一起變動，而且區區數次嘗試不是發生率。有兩個各自獨立、gate 不同的注入：
+> 訂閱層級那個在 Max 上實測消失，session guidance 那個仍在。**兩種方案都不可靠。**
 > 需要 orchestration lifecycle 時，請在 request 加上
 > `Use pilotfish and delegate eligible work to the named agents.`。
-> 明確指定後，在兩個已測方案上，已實測的 `scout`、`plan-verifier`、
-> `mech-executor` 與 `verifier` paths 都可正常啟動；其他 roles 未測。
+> 明確指定後，已實測的 `scout`、`plan-verifier`、`mech-executor` 與 `verifier`
+> paths 都可正常啟動——但那只在 Pro 帳號上跑過，明確臂沒有在 Max 上執行；
+> 其他 roles，以及 Max 上的明確指定，都未測。
 > 目前不把此觀察歸因於 prompt compression：未修改的 v1.3.3 cue-free control
 > 與 v1.3.4 壓縮版同樣是 0 dispatch。逐格證據，以及那些記錄裡「cue-free」
 > 究竟指什麼、不指什麼，見

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -56,17 +56,23 @@ Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-o
 
 > **設定根目錄**：以下路徑是預設值。若你設了 [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars)，下列每個 `~/.claude/` 路徑都改在該目錄底下；[安裝 runbook](./install/AGENT-INSTALL.md) 會在 Step 0 解析它。
 
-> ⚠️ **一個已測試的 Claude Pro 環境需要明確 opt-in 才能委派 Agent。**
-> 在一個使用 Claude Code 2.1.220 的 first-party Pro 帳號上，較高優先級的
-> Agent tool contract 會阻止 spawn，除非使用者明確要求 agents。使用者層的
-> `CLAUDE.md` 無法覆蓋該 session contract，因此成功安裝 pilotfish 不代表
-> 所有環境都會無提示自動委派。需要 orchestration lifecycle 時，請在 request
-> 加上 `Use pilotfish and delegate eligible work to the named agents.`。
-> 明確指定後，已實測的 `scout`、`plan-verifier`、`mech-executor` 與
-> `verifier` paths 可正常啟動；其他 roles 未測。v1.3.4 壓縮版與未修改的
-> v1.3.3 cue-free control 都是 0 dispatch，因此目前不把此觀察歸因於
-> prompt compression。追蹤：
-> [#29](https://github.com/Nanako0129/pilotfish/issues/29)。
+> ⚠️ **安裝成功不保證會自動委派。需要 lifecycle 時請加上明確 opt-in。**
+> Claude Code 較高優先級的指示可能壓制 Agent 委派，而使用者層的 `CLAUDE.md`
+> 無法覆蓋它們。這不限於單一訂閱方案。在一個使用 Claude Code 2.1.220 的
+> first-party Pro 帳號上，兩次 cue-free schema attempt 都沒有委派；同一台機器、
+> 同一個 client 升級 Max 之後，一組四格 baseline **四次正向嘗試只有一次**達到預期
+> 拓撲——十二檔案的 mechanical 那格兩次全失敗，主 session 自己改完全部檔案。
+> 比 Pro 好，但遠談不上可靠。有兩個各自獨立、gate 不同的注入：訂閱層級那個在
+> Max 上實測消失，session guidance 那個仍在。**兩種方案都受影響，只是方式不同。**
+> 需要 orchestration lifecycle 時，請在 request 加上
+> `Use pilotfish and delegate eligible work to the named agents.`。
+> 明確指定後，在兩個已測方案上，已實測的 `scout`、`plan-verifier`、
+> `mech-executor` 與 `verifier` paths 都可正常啟動；其他 roles 未測。
+> 目前不把此觀察歸因於 prompt compression：未修改的 v1.3.3 cue-free control
+> 與 v1.3.4 壓縮版同樣是 0 dispatch。逐格證據，以及那些記錄裡「cue-free」
+> 究竟指什麼、不指什麼，見
+> [`benchmarks/spontaneous-dispatch`](./benchmarks/spontaneous-dispatch/README.zh-TW.md)。
+> 追蹤：[#29](https://github.com/Nanako0129/pilotfish/issues/29)。
 
 <details>
 <summary><b>機制是什麼</b>——兩個各自獨立的注入，以及哪些能主張、哪些不能</summary>

--- a/benchmarks/spontaneous-dispatch/README.md
+++ b/benchmarks/spontaneous-dispatch/README.md
@@ -172,6 +172,23 @@ EOF
 
 `--dangerously-skip-permissions` is limited to these disposable fixtures.
 
+## v1.3.7 Max prompt baseline
+
+Recorded under `v1_3_7_max_prompt_baseline` in [`results.json`](./results.json). It is the reference point for the prompt work tracked on [#29](https://github.com/Nanako0129/pilotfish/issues/29): what the shipped v1.3.7 policy does on a Max account across positive and negative cells together, so a candidate policy can be measured against it rather than against an impression.
+
+| Cell | Expected | a | b |
+|---|---|---|---|
+| Mechanical, 12 files | one foreground `mech-executor`, no main-session mutation | **FAIL** — 0 Agent calls, main rewrote all 12 | **FAIL** — 0 Agent calls, main rewrote all 12 by shell redirection |
+| Tightly coupled bug | negative: main owns diagnosis and first fix | PASS — 0 Agent calls, one `Edit` | PASS — 0 Agent calls, one `Edit` |
+| Schema lifecycle | `plan-verifier`, implement, `verifier` | PASS — 2 Agent calls | **FAIL** — 0 Agent calls, approval gate skipped |
+| Routine docs | negative: zero Agent calls | PASS | PASS |
+
+**Positive attempts: 1 of 4. Negative attempts: 4 of 4. Correctness: every cell passed its tests.** Every failure is a routing failure, never a wrong result. The negative side has headroom and the positive side does not, which is the shape a candidate has to improve without disturbing.
+
+The mechanical cell is the sharpest comparison available: the same prompt and fixture passed 2 of 2 on Opus 4.8 with clients 2.1.217 and 2.1.218, recorded above as `opus-v1.3.1-candidate-1-mechanical` and `opus-v1.3.1-release-payload-mechanical`. It now fails 2 of 2. The observable capability regressed, but the model, the client and the policy version all differ between those records and this one, so the baseline is a starting point, not an attribution.
+
+This baseline is the first set of runs to fix both contamination sources found in review: `agents.json` is passed to `--agents` and never copied in, and every capture is written outside the disposable repository. `git ls-files --others --exclude-standard` is empty in all five newly run directories. The four cells reused from the paired matrix predate the capture fix and each says so.
+
 ## Claim limits
 
 | Limit | Consequence |

--- a/benchmarks/spontaneous-dispatch/README.md
+++ b/benchmarks/spontaneous-dispatch/README.md
@@ -187,7 +187,7 @@ Recorded under `v1_3_7_max_prompt_baseline` in [`results.json`](./results.json).
 
 The mechanical cell is the sharpest comparison available: the same prompt and fixture passed 2 of 2 on Opus 4.8 with clients 2.1.217 and 2.1.218, recorded above as `opus-v1.3.1-candidate-1-mechanical` and `opus-v1.3.1-release-payload-mechanical`. It now fails 2 of 2. The observable capability regressed, but the model, the client and the policy version all differ between those records and this one, so the baseline is a starting point, not an attribution.
 
-This baseline is the first set of runs to fix both contamination sources found in review: `agents.json` is passed to `--agents` and never copied in, and every capture is written outside the disposable repository. `git ls-files --others --exclude-standard` is empty in all five newly run directories. The four cells reused from the paired matrix predate the capture fix and each says so.
+This baseline is the first set of runs to fix both contamination sources found in review: `agents.json` is passed to `--agents` and never copied in, and every capture is written outside the disposable repository. `git ls-files --others --exclude-standard` is empty in all five newly run directories. The three attempts reused from the paired matrix — schema a and b, routine a — predate the capture fix and each says so.
 
 ## Claim limits
 

--- a/benchmarks/spontaneous-dispatch/README.zh-TW.md
+++ b/benchmarks/spontaneous-dispatch/README.zh-TW.md
@@ -187,7 +187,7 @@ EOF
 
 Mechanical 是目前最銳利的比較：同一份 prompt、同一個 fixture，在 Opus 4.8 與 client 2.1.217／2.1.218 上曾經二取二通過，即上面的 `opus-v1.3.1-candidate-1-mechanical` 與 `opus-v1.3.1-release-payload-mechanical`。現在二取二失敗。可觀察能力確實退化，但那些記錄與這一組之間，model、client 與政策版本三者都不同，所以這份 baseline 是起點，不是歸因。
 
-這是第一組同時修掉 review 找出的兩個污染源的 run：`agents.json` 只經 `--agents` 傳入、絕不複製進去，每一份 capture 都寫在拋棄式 repo 之外。五個新建目錄的 `git ls-files --others --exclude-standard` 都是空的。從配對 matrix 沿用的那四格早於 capture 修正，各自都已載明。
+這是第一組同時修掉 review 找出的兩個污染源的 run：`agents.json` 只經 `--agents` 傳入、絕不複製進去，每一份 capture 都寫在拋棄式 repo 之外。五個新建目錄的 `git ls-files --others --exclude-standard` 都是空的。從配對 matrix 沿用的那三次 attempt——schema a 與 b、routine a——早於 capture 修正，各自都已載明。
 
 ## 結論邊界
 

--- a/benchmarks/spontaneous-dispatch/README.zh-TW.md
+++ b/benchmarks/spontaneous-dispatch/README.zh-TW.md
@@ -172,6 +172,23 @@ EOF
 
 `--dangerously-skip-permissions` 僅限這些拋棄式 fixture 使用。
 
+## v1.3.7 Max prompt baseline
+
+記錄在 [`results.json`](./results.json) 的 `v1_3_7_max_prompt_baseline`。它是 [#29](https://github.com/Nanako0129/pilotfish/issues/29) 上 prompt 工作的比較基準：出貨的 v1.3.7 政策在 Max 帳號上、正向與負向格一起量出來的行為，讓候選政策有東西可比，而不是憑印象。
+
+| 測試格 | 預期 | a | b |
+|---|---|---|---|
+| Mechanical，12 檔案 | 一個 foreground `mech-executor`，主 session 不動原始碼 | **FAIL** — 0 Agent call，主 session 改完 12 檔 | **FAIL** — 0 Agent call，用 shell 重導向改完 12 檔 |
+| 緊耦合 bug | 負向：主 session 自己診斷與首次修正 | PASS — 0 Agent call，一個 `Edit` | PASS — 0 Agent call，一個 `Edit` |
+| Schema lifecycle | `plan-verifier`、實作、`verifier` | PASS — 2 個 Agent call | **FAIL** — 0 Agent call，跳過 approval gate |
+| Routine docs | 負向：零 Agent call | PASS | PASS |
+
+**正向嘗試：四取一。負向嘗試：四取四。正確性：每一格的測試都通過。** 所有失敗都是 routing 失敗，沒有一次是結果錯誤。負向那側有餘裕、正向那側沒有——候選要改善的正是這個形狀，而且不能把負向那側弄壞。
+
+Mechanical 是目前最銳利的比較：同一份 prompt、同一個 fixture，在 Opus 4.8 與 client 2.1.217／2.1.218 上曾經二取二通過，即上面的 `opus-v1.3.1-candidate-1-mechanical` 與 `opus-v1.3.1-release-payload-mechanical`。現在二取二失敗。可觀察能力確實退化，但那些記錄與這一組之間，model、client 與政策版本三者都不同，所以這份 baseline 是起點，不是歸因。
+
+這是第一組同時修掉 review 找出的兩個污染源的 run：`agents.json` 只經 `--agents` 傳入、絕不複製進去，每一份 capture 都寫在拋棄式 repo 之外。五個新建目錄的 `git ls-files --others --exclude-standard` 都是空的。從配對 matrix 沿用的那四格早於 capture 修正，各自都已載明。
+
 ## 結論邊界
 
 | 限制 | 影響 |

--- a/benchmarks/spontaneous-dispatch/agent-calls.json
+++ b/benchmarks/spontaneous-dispatch/agent-calls.json
@@ -52,6 +52,11 @@
     ],
     "v1.3.7-max-cue-free-schema-b-turn-1": [],
     "v1.3.7-max-cue-free-schema-b-turn-2": [],
-    "v1.3.7-max-cue-free-routine-docs": []
+    "v1.3.7-max-cue-free-routine-docs": [],
+    "v1.3.7-max-baseline-mechanical-a": [],
+    "v1.3.7-max-baseline-mechanical-b": [],
+    "v1.3.7-max-baseline-bug-a": [],
+    "v1.3.7-max-baseline-bug-b": [],
+    "v1.3.7-max-baseline-routine-b": []
   }
 }

--- a/benchmarks/spontaneous-dispatch/results.json
+++ b/benchmarks/spontaneous-dispatch/results.json
@@ -498,5 +498,141 @@
         }
       }
     }
+  },
+  "v1_3_7_max_prompt_baseline": {
+    "purpose": "Reference point for prompt work on #29. Records what the shipped v1.3.7 policy does on a Max account across both positive and negative dispatch cells, so a later policy candidate can be measured against it rather than against an impression. Any candidate that raises positive dispatch must be shown not to break the negative cells, which is why they are baselined together.",
+    "environment": {
+      "account_plan": "max",
+      "auth_method": "claude.ai",
+      "api_provider": "firstParty",
+      "client_version": "2.1.220",
+      "requested_model": "opus",
+      "observed_main_model": "claude-opus-5",
+      "effort": "high",
+      "setting_sources": [
+        "project",
+        "local"
+      ],
+      "policy_version": "1.3.7",
+      "policy_sha256": "b26ef4a6a0e02575a39ecc8d3303a8cd7f9e9180548311de399fff527efb3b75",
+      "policy_source": "`templates/claude-md.orchestration.md` at v1.3.7, byte-identical to `../verifier-boundary/gate-snapshot-v2/CLAUDE.md`",
+      "agents_json_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f"
+    },
+    "hygiene": "This baseline fixes both contamination sources the #43 review found. `agents.json` is passed to `--agents` and never copied into a repository, and every stream capture is written outside the disposable repository. `git ls-files --others --exclude-standard` returns empty in all five newly run directories, so the tracked tree is the whole tree the session could see. The four earlier Max cells reused here did not have the second property, and each says so.",
+    "cells": {
+      "mechanical": {
+        "expected_topology": "Exactly one foreground `mech-executor`; the main session performs no source mutation; 12 adapter files change; 12/12 tests pass.",
+        "baseline_tree": "7d671f5f3f8bf372e9caecd21bbc4a7cba224b90",
+        "attempts": [
+          {
+            "id": "a",
+            "agent_calls": 0,
+            "topology": "FAIL",
+            "observed": "Main session enumerated and catted the adapters, rewrote all twelve with a `cat > \"$f\"` heredoc loop, read them back, rewrote each again with a `Write` call, then ran the suite. Both mutation paths were the main session's. No Agent call.",
+            "tests_after": "12 passed, 0 failed",
+            "changed_paths_count": 12,
+            "client_reported_cost_usd": 0.931978,
+            "raw_stream_sha256": "567577c4cce8bca9fccf84945c3f2d0cf4f77379cbfbc8e7949a31e0b8524d12"
+          },
+          {
+            "id": "b",
+            "agent_calls": 0,
+            "topology": "FAIL",
+            "observed": "Main session listed and catted the adapters, then rewrote all twelve with `cat > \"$f\"` and `cat >| \"$f\"` heredoc loops, and ran the suite. No Agent call and no `Write` tool use at all — the mutation path was shell redirection, which this benchmark's input contract rejects outright.",
+            "tests_after": "12 passed, 0 failed",
+            "changed_paths_count": 12,
+            "client_reported_cost_usd": 0.3240865,
+            "raw_stream_sha256": "806c11e6564b1f5799a869de6be587603f68e6b91df231b6079da29e71d22171"
+          }
+        ]
+      },
+      "tightly_coupled_bug": {
+        "expected_topology": "Negative cell. Main session owns diagnosis and the first minimal fix; no discovery or implementation agent before the fix and the focused pass.",
+        "baseline_tree": "3f4f36922824ebff00775d2ab4cb72e6ee87ec4c",
+        "attempts": [
+          {
+            "id": "a",
+            "agent_calls": 0,
+            "topology": "PASS",
+            "observed": "Three Bash triage commands, five reads, one `Edit` to `src/reducer.js`, then the tests. No Agent call before or after the fix.",
+            "tests_after": "2 passed, 0 failed",
+            "changed_paths_count": 1,
+            "client_reported_cost_usd": 0.370751,
+            "raw_stream_sha256": "623cf6aabcc248e68b73daa4cb8e61e160d726183ca07c6c7151be9736f7ae32"
+          },
+          {
+            "id": "b",
+            "agent_calls": 0,
+            "topology": "PASS",
+            "observed": "Same shape with one extra triage command: four Bash calls, five reads, one `Edit` to `src/reducer.js`, then the tests. No Agent call.",
+            "tests_after": "2 passed, 0 failed",
+            "changed_paths_count": 1,
+            "client_reported_cost_usd": 0.3730545,
+            "raw_stream_sha256": "d5c318079f30a828bc97d1078343b60cc2ab2fc79bd0c8b232cc2329c03921b6"
+          }
+        ]
+      },
+      "schema_lifecycle": {
+        "expected_topology": "`plan-verifier` before approval, implementation, then an outcome `verifier`.",
+        "baseline_tree": "d31e20963655d0e8d08ec94e15395b0a0fc6e582",
+        "attempts": [
+          {
+            "id": "a",
+            "agent_calls": 2,
+            "topology": "PASS",
+            "observed": "Recorded in `v1_3_7_paired_opt_in_matrix.cue_free.max`. `plan-verifier` returned bare READY, the main session implemented, and an outcome `verifier` returned CONFIRMED.",
+            "tests_after": "4 passed, 0 failed",
+            "evidence": "#v1_3_7_paired_opt_in_matrix",
+            "caveat": "Ran before the capture-placement fix, so its run directory held untracked `t1.jsonl` and `t2.jsonl`."
+          },
+          {
+            "id": "b",
+            "agent_calls": 0,
+            "topology": "FAIL",
+            "observed": "Dispatched nothing and skipped the approval gate, writing both source files in turn 1.",
+            "tests_after": "5 passed, 0 failed",
+            "evidence": "#v1_3_7_paired_opt_in_matrix",
+            "caveat": "Same capture-placement caveat as attempt a."
+          }
+        ]
+      },
+      "routine_docs_control": {
+        "expected_topology": "Negative cell. Zero Agent calls.",
+        "baseline_tree": "d31e20963655d0e8d08ec94e15395b0a0fc6e582",
+        "attempts": [
+          {
+            "id": "a",
+            "agent_calls": 0,
+            "topology": "PASS",
+            "observed": "Recorded in `v1_3_7_paired_opt_in_matrix.cue_free.max`.",
+            "tests_after": "1 passed, 0 failed",
+            "evidence": "#v1_3_7_paired_opt_in_matrix",
+            "caveat": "Ran before the capture-placement fix; its directory held an untracked `stream.jsonl`."
+          },
+          {
+            "id": "b",
+            "agent_calls": 0,
+            "topology": "PASS",
+            "observed": "Listed files, read and edited `README.md`, ran the suite. No Agent call.",
+            "tests_after": "1 passed, 0 failed",
+            "changed_paths_count": 1,
+            "client_reported_cost_usd": 0.219294,
+            "raw_stream_sha256": "76686e6a6ffa00de04b86acabd7443cf2b3f17f302b4fc20823926961e6ef8ab"
+          }
+        ]
+      }
+    },
+    "scoreboard": {
+      "positive_attempts": "1 of 4 reached the expected topology: mechanical 0 of 2, schema lifecycle 1 of 2.",
+      "negative_attempts": "4 of 4 correct: tightly coupled bug 2 of 2, routine docs control 2 of 2.",
+      "correctness": "5 of 5 newly run cells passed their repository tests, as did the four earlier Max cells. Every failure recorded here is a routing failure, never a wrong result.",
+      "reading": "The negative side has headroom and the positive side does not. A policy candidate has room to push harder; the thing to watch is whether pushing breaks the two negative cells that currently hold."
+    },
+    "regression_context": "The mechanical cell is the sharpest comparison available, because the same prompt file and the same fixture were run before. `runs` in this file records `opus-v1.3.1-candidate-1-mechanical` and `opus-v1.3.1-release-payload-mechanical` both passing the cell with exactly one foreground `mech-executor`, on Opus 4.8 and clients 2.1.217 and 2.1.218. The same cell now fails 2 of 2 on Opus 5 and client 2.1.220. The observable capability regressed. The cause is not established: the model, the client and the policy version all differ between those records and this one, and this baseline holds the policy constant rather than isolating any of them. It is recorded as the measured starting point for prompt work, not as an attribution.",
+    "claim_boundary": "One account, one machine, one client build, one model. Two attempts per cell. Establishes the shipped policy's behaviour under these exact conditions as a comparison point; it is not a dispatch rate and does not generalise across workloads, models or plans.",
+    "cost": {
+      "newly_run_streams_usd": 2.219164,
+      "note": "Five streams: mechanical a and b, bug a and b, routine b. Derived by summing the per-attempt values recorded above. The two schema attempts and routine attempt a were run earlier and are costed in `v1_3_7_paired_opt_in_matrix.cue_free.max`."
+    }
   }
 }

--- a/benchmarks/spontaneous-dispatch/results.json
+++ b/benchmarks/spontaneous-dispatch/results.json
@@ -516,9 +516,11 @@
       "policy_version": "1.3.7",
       "policy_sha256": "b26ef4a6a0e02575a39ecc8d3303a8cd7f9e9180548311de399fff527efb3b75",
       "policy_source": "`templates/claude-md.orchestration.md` at v1.3.7, byte-identical to `../verifier-boundary/gate-snapshot-v2/CLAUDE.md`",
-      "agents_json_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f"
+      "agents_json_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+      "agents_json_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+      "agents_json_digest_note": "`agents_json_sha256` is the committed snapshot file. `agents_json_runtime_sha256` is what the client actually received: the runner passes `\"$(<\"$G/agents.json\")\"`, and command substitution strips the trailing newline, so the payload hash differs from the file hash. The exercised payload is the runtime one."
     },
-    "hygiene": "This baseline fixes both contamination sources the #43 review found. `agents.json` is passed to `--agents` and never copied into a repository, and every stream capture is written outside the disposable repository. `git ls-files --others --exclude-standard` returns empty in all five newly run directories, so the tracked tree is the whole tree the session could see. The four earlier Max cells reused here did not have the second property, and each says so.",
+    "hygiene": "This baseline fixes both contamination sources the #43 review found. `agents.json` is passed to `--agents` and never copied into a repository, and every stream capture is written outside the disposable repository. `git ls-files --others --exclude-standard` returns empty in all five newly run directories, so the tracked tree is the whole tree the session could see. The three earlier Max attempts reused here — schema lifecycle a and b, routine docs a, five underlying streams between them — did not have the second property, and each says so.",
     "cells": {
       "mechanical": {
         "expected_topology": "Exactly one foreground `mech-executor`; the main session performs no source mutation; 12 adapter files change; 12/12 tests pass.",
@@ -625,14 +627,26 @@
     "scoreboard": {
       "positive_attempts": "1 of 4 reached the expected topology: mechanical 0 of 2, schema lifecycle 1 of 2.",
       "negative_attempts": "4 of 4 correct: tightly coupled bug 2 of 2, routine docs control 2 of 2.",
-      "correctness": "5 of 5 newly run cells passed their repository tests, as did the four earlier Max cells. Every failure recorded here is a routing failure, never a wrong result.",
+      "correctness": "5 of 5 newly run attempts passed their repository tests, as did the 3 reused earlier ones. Every failure recorded here is a routing failure, never a wrong result.",
       "reading": "The negative side has headroom and the positive side does not. A policy candidate has room to push harder; the thing to watch is whether pushing breaks the two negative cells that currently hold."
     },
     "regression_context": "The mechanical cell is the sharpest comparison available, because the same prompt file and the same fixture were run before. `runs` in this file records `opus-v1.3.1-candidate-1-mechanical` and `opus-v1.3.1-release-payload-mechanical` both passing the cell with exactly one foreground `mech-executor`, on Opus 4.8 and clients 2.1.217 and 2.1.218. The same cell now fails 2 of 2 on Opus 5 and client 2.1.220. The observable capability regressed. The cause is not established: the model, the client and the policy version all differ between those records and this one, and this baseline holds the policy constant rather than isolating any of them. It is recorded as the measured starting point for prompt work, not as an attribution.",
     "claim_boundary": "One account, one machine, one client build, one model. Two attempts per cell. Establishes the shipped policy's behaviour under these exact conditions as a comparison point; it is not a dispatch rate and does not generalise across workloads, models or plans.",
     "cost": {
       "newly_run_streams_usd": 2.219164,
-      "note": "Five streams: mechanical a and b, bug a and b, routine b. Derived by summing the per-attempt values recorded above. The two schema attempts and routine attempt a were run earlier and are costed in `v1_3_7_paired_opt_in_matrix.cue_free.max`."
+      "note": "Five streams: mechanical a and b, bug a and b, routine b. Derived by summing the per-attempt values recorded above. The three reused attempts — schema a, schema b, routine a — were run earlier and are costed in `v1_3_7_paired_opt_in_matrix.cue_free.max`."
+    },
+    "evidence": {
+      "traces": "./traces.json",
+      "agent_calls": "./agent-calls.json",
+      "run_keys": [
+        "v1.3.7-max-baseline-mechanical-a",
+        "v1.3.7-max-baseline-mechanical-b",
+        "v1.3.7-max-baseline-bug-a",
+        "v1.3.7-max-baseline-bug-b",
+        "v1.3.7-max-baseline-routine-b"
+      ],
+      "note": "Sanitized tool sequences and Agent-call records are committed for the five newly run streams, as for every other run in this file. The three reused attempts are keyed under `v1.3.7-max-cue-free-*`."
     }
   }
 }

--- a/benchmarks/spontaneous-dispatch/traces.json
+++ b/benchmarks/spontaneous-dispatch/traces.json
@@ -368,6 +368,210 @@
         "store_mjs_unchanged_sha256": "84cce7009177d0817e417052da73810696727515f0c53daf0c0ac6ddbf168a18",
         "store_test_mjs_unchanged_sha256": "73cf0fb1ae65995f8018d396614095a91d0cbda99796816978103664549962a6"
       }
+    },
+    "v1.3.7-max-baseline-mechanical-a": {
+      "top_level_tools": [
+        "Bash",
+        "Bash",
+        "Read",
+        "Bash",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Bash"
+      ],
+      "top_level_source_write_tools": [
+        "Bash",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write",
+        "Write"
+      ],
+      "agent_calls": [],
+      "note": "v1.3.7 Max prompt baseline; no Agent call was made. Topology FAIL: the main session was the sole mutation path, first through a heredoc loop and then through twelve individual writes.",
+      "top_level_bash_actions": [
+        "list project files",
+        "show adapter sources and package.json",
+        "write the normalize implementation to each adapter by heredoc loop",
+        "run the test suite"
+      ],
+      "acceptance": {
+        "tests_after": "12 passed, 0 failed",
+        "changed_paths": [
+          "alpha.js",
+          "bravo.js",
+          "charlie.js",
+          "delta.js",
+          "echo.js",
+          "foxtrot.js",
+          "golf.js",
+          "hotel.js",
+          "india.js",
+          "juliet.js",
+          "kilo.js",
+          "lima.js"
+        ]
+      }
+    },
+    "v1.3.7-max-baseline-mechanical-b": {
+      "top_level_tools": [
+        "Bash",
+        "Bash",
+        "Bash",
+        "Bash",
+        "Bash"
+      ],
+      "top_level_source_write_tools": [
+        "Bash",
+        "Bash"
+      ],
+      "agent_calls": [],
+      "note": "v1.3.7 Max prompt baseline; no Agent call was made. Topology FAIL: no `Write` tool use at all — both mutation commands were shell redirection into the adapter files, which this benchmark's input contract rejects outright.",
+      "top_level_bash_actions": [
+        "list the repository and adapters directory",
+        "print all adapter modules, package.json and tests",
+        "rewrite normalize in all adapter modules by heredoc redirection",
+        "rewrite normalize in all adapter modules by heredoc redirection, second pass",
+        "run the test suite"
+      ],
+      "acceptance": {
+        "tests_after": "12 passed, 0 failed",
+        "changed_paths": [
+          "alpha.js",
+          "bravo.js",
+          "charlie.js",
+          "delta.js",
+          "echo.js",
+          "foxtrot.js",
+          "golf.js",
+          "hotel.js",
+          "india.js",
+          "juliet.js",
+          "kilo.js",
+          "lima.js"
+        ]
+      }
+    },
+    "v1.3.7-max-baseline-bug-a": {
+      "top_level_tools": [
+        "Bash",
+        "Bash",
+        "Bash",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Edit",
+        "Bash",
+        "Bash"
+      ],
+      "top_level_source_write_tools": [
+        "Edit"
+      ],
+      "agent_calls": [],
+      "note": "v1.3.7 Max prompt baseline; no Agent call was made. Negative cell, topology PASS: the main session owned diagnosis and the first minimal fix, with no agent before or after it. This stream's Bash calls carried no description field; the actions below are read off the commands.",
+      "top_level_bash_actions": [
+        "survey the repository",
+        "locate the status-line sources and tests",
+        "run the test suite",
+        "re-run the test suite after the fix"
+      ],
+      "acceptance": {
+        "tests_after": "2 passed, 0 failed",
+        "changed_paths": [
+          "src/reducer.js"
+        ]
+      }
+    },
+    "v1.3.7-max-baseline-bug-b": {
+      "top_level_tools": [
+        "Bash",
+        "Bash",
+        "Bash",
+        "Bash",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Read",
+        "Edit",
+        "Bash",
+        "Bash"
+      ],
+      "top_level_source_write_tools": [
+        "Edit"
+      ],
+      "agent_calls": [],
+      "note": "v1.3.7 Max prompt baseline; no Agent call was made. Negative cell, topology PASS: same shape as attempt a with one extra triage command.",
+      "top_level_bash_actions": [
+        "list the repository root and read package.json",
+        "find status-line related files",
+        "list src and test files",
+        "run the test suite",
+        "run the test suite after the fix",
+        "check the clone-ownership boundary holds"
+      ],
+      "acceptance": {
+        "tests_after": "2 passed, 0 failed",
+        "changed_paths": [
+          "src/reducer.js"
+        ]
+      }
+    },
+    "v1.3.7-max-baseline-routine-b": {
+      "top_level_tools": [
+        "Bash",
+        "Bash",
+        "Edit",
+        "Bash"
+      ],
+      "top_level_source_write_tools": [
+        "Edit"
+      ],
+      "agent_calls": [],
+      "note": "v1.3.7 Max prompt baseline; no Agent call was made. Negative cell, topology PASS; the routine control is required to dispatch nothing.",
+      "top_level_bash_actions": [
+        "list files and show README",
+        "show package.json",
+        "run the repository test command"
+      ],
+      "acceptance": {
+        "tests_after": "1 passed, 0 failed",
+        "changed_paths": [
+          "README.md"
+        ],
+        "final_readme_sha256": "1bafe869338e9833d19a14cf90b13e5c51f68e2ab458295cfbcf65fcbb98ed30"
+      }
     }
   }
 }


### PR DESCRIPTION
Establishes the measurement starting point for prompt work on #29, and fixes a README warning the Max evidence had already invalidated.

## Baseline

`v1_3_7_max_prompt_baseline` — shipped v1.3.7 policy (`b26ef4a6…`), Max account, client 2.1.220, Opus 5 effort high. Four cells, two attempts each. Positive and negative cells together, because a candidate that raises dispatch is only an improvement if the negative cells still hold.

| Cell | Expected | a | b |
|---|---|---|---|
| Mechanical, 12 files | one `mech-executor`, no main mutation | **FAIL** | **FAIL** |
| Tightly coupled bug | negative | PASS | PASS |
| Schema lifecycle | `plan-verifier` → implement → `verifier` | PASS | **FAIL** |
| Routine docs | negative | PASS | PASS |

**Positive 1 of 4, negative 4 of 4, correctness 5 of 5.** Every failure is a routing failure, never a wrong result. Both mechanical attempts had the main session rewrite all twelve adapters; attempt b did it entirely through heredoc redirection with no `Write` tool use.

The mechanical cell passed 2 of 2 on Opus 4.8 with clients 2.1.217 and 2.1.218 and now fails 2 of 2. `regression_context` records the regression while stating that model, client and policy version all differ, so it is a starting point and not an attribution.

## Hygiene

First runs to fix both contamination sources from the #43 review: `agents.json` passed via `--agents` and never copied in, captures written outside the disposable repository. `git ls-files --others --exclude-standard` is empty in all five new directories. The four reused cells predate the capture fix and say so inline.

## Warning rescoped

Both top-level READMEs framed the limitation as Pro-specific, so a Max user would conclude they were unaffected. They now lead with "a successful install does not guarantee automatic delegation", give the Pro and Max results side by side, and state that both plans are affected differently.

Refs #29.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SGMQdjkoh8CCsRwm1Mi5fG