### PR TITLE
docs(benchmarks): record cue-free TUI diagnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ Three layers, three files' worth of configuration, all under `~/.claude/`:
 > candidate. Per-cell evidence, including what "cue-free" does and does not mean
 > in those records, is in
 > [`benchmarks/spontaneous-dispatch`](./benchmarks/spontaneous-dispatch/README.md).
+> A later Calico 2.1.223 TUI attempt also stayed direct. Four readable thinking
+> blocks exposed the model's stated decision basis; the bounded evidence and its
+> claim limits are in [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json).
 > Tracking: [#29](https://github.com/Nanako0129/pilotfish/issues/29).
 
 <details>
@@ -105,7 +108,7 @@ Three separate string searches across the official builds we retain:
 
 **Claim boundary.** A string present in a binary is not an instruction active in a session, and three builds cannot establish when anything was introduced upstream — [anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988) is the source for that side of it. We found no documented user-facing setting that opts in persistently, and we do not claim none exists; that needs CLI and settings evidence we have not gathered. As corroboration only, from our own repackaging of Claude Code native builds, [Calico](https://github.com/Nanako0129/calico-claude): the tool-description paragraph is present in all ten retained builds between 2.1.207 and 2.1.220 — a non-contiguous set, not every release in that range.
 
-**Cheapest check available.** Ask a fresh session what its delegation policy is. In the session where we looked, the paragraph was present in the Agent tool description and the session could quote its own constraint — no patched build, no proxy, no transcript analysis needed.
+**Diagnostic, not proof.** Asking a fresh session to describe its delegation policy can reveal the model's own account of the constraint. The later Calico 2.1.223 TUI diagnostic persisted four readable thinking blocks and showed the model treating a higher-priority instruction as preventing AgentTool use. This is behavioral evidence, not the exact active system-prompt bytes; see [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json).
 
 **If you also run [claude-router](https://github.com/Serhii-Leniv/claude-router):** do not enable `forceRoute` while pilotfish is installed. It overrides the model each agent sets in its own frontmatter, which is exactly how pilotfish gives `verifier` a fresh Opus context; an Opus-pinned role was observed running on `claude-sonnet-5`. That tool's `restoreDelegation` option strips the second injection above.
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -74,6 +74,9 @@ Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-o
 > 與 v1.3.4 壓縮版同樣是 0 dispatch。逐格證據，以及那些記錄裡「cue-free」
 > 究竟指什麼、不指什麼，見
 > [`benchmarks/spontaneous-dispatch`](./benchmarks/spontaneous-dispatch/README.zh-TW.md)。
+> 後續的 Calico 2.1.223 TUI 嘗試也維持 direct。四個可讀的 thinking block
+> 顯示模型自己陳述的決策依據；有邊界的證據與主張限制記錄在
+> [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json)。
 > 追蹤：[#29](https://github.com/Nanako0129/pilotfish/issues/29)。
 
 <details>
@@ -100,7 +103,7 @@ Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-o
 
 **主張邊界。** 字串存在於 binary 不等於該指令在 session 中生效；三個 build 也無法證明上游何時引入某項東西——那一側的來源是 [anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988)。我們沒有找到任何有文件的使用者層設定可以持久 opt-in，但也不主張這種設定不存在；那需要我們尚未蒐集的 CLI 與 settings 證據。以下僅作為佐證，來自我們自己重新封裝的 Claude Code 原生 build [Calico](https://github.com/Nanako0129/calico-claude)：tool-description 段落存在於 2.1.207 與 2.1.220 之間所有十個留存的 build——那是一組不連續的版本，不是該區間的每一個 release。
 
-**最省力的檢查方式。** 開一個新 session，問它自己的委派政策。在我們檢查的那個 session 裡，該段落存在於 Agent tool description，而 session 被問到時能引用自己的限制——不需要 patch 過的 build、不需要 proxy、不需要分析 transcript。
+**這是診斷，不是證明。** 開一個新 session 詢問其委派政策，可以取得模型對限制的自述。後續的 Calico 2.1.223 TUI 診斷保存了四個可讀的 thinking block，並顯示模型把較高優先級的指令視為禁止使用 AgentTool。這是行為證據，不是實際生效的 system-prompt 原始 bytes；見 [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json)。
 
 **如果你同時使用 [claude-router](https://github.com/Serhii-Leniv/claude-router)：** 裝了 pilotfish 就不要開 `forceRoute`。它會覆蓋每個 agent 在自己 frontmatter 設定的模型，而那正是 pilotfish 讓 `verifier` 拿到全新 Opus context 的方式；已有實測觀察到一個釘在 Opus 的角色跑在 `claude-sonnet-5` 上。該工具的 `restoreDelegation` 選項則會剝除上面第二個注入。
 

--- a/benchmarks/spontaneous-dispatch/README.md
+++ b/benchmarks/spontaneous-dispatch/README.md
@@ -223,6 +223,14 @@ Schema review and implementation routing are separate decisions. Serialization m
 
 [`issue-29-recovery.json`](./issue-29-recovery.json) binds the repository policy, injection method, generated agents payload, prompts, costs, and raw-stream hashes for both the earlier Gate candidate and the release replay. The release replay ran ten completed invocations under an `$8` hard cap and reported `$3.89565485`. Claude Code updated from 2.1.220 to 2.1.221 between the two mechanical attempts; both passed, and the remaining cells ran on 2.1.221. The client transcripts observe the expected fixture `CLAUDE.md` sizes but do not expose a digest of the bytes incorporated into the runtime system prompt, so this is not an exact-loaded-policy causal claim. Stream and final-state evidence are not used to claim causal mutation ownership.
 
+## Calico TUI diagnostic
+
+The later cue-free candidate tried to express delegation as a standing user instruction inside `CLAUDE.md`. Four mechanical cells on Claude Code or Calico 2.1.223, Opus 5, high effort made zero Agent calls, changed all twelve adapters in the main session, and passed 12/12 tests. The experiment stopped there; correctness did not satisfy the required ownership topology.
+
+The final cell used a persistent interactive Calico TUI with its existing full tool-output patch enabled. All four thinking blocks were readable. Their bounded summary is that the model treated a higher-priority system instruction as overriding the candidate's AgentTool permission; it separately printed `dispatch: direct — 12 identical one-shot edits, mechanical but faster inline than briefing a worker.` The TUI showed six Bash calls, no `Agent` or `Task` call, and complete command/output rows.
+
+[`cue-free-tui.json`](./cue-free-tui.json) binds the reconstructable policy delta, prompt, fixture, generated agents payload, patched client binary, transcript hash, observable tools, final paths, tests, and approximately `$2.6381705` campaign cost. The raw thinking is not committed. This is evidence of the model's stated decision basis, not the exact active system-prompt bytes; it closes this `CLAUDE.md` candidate, not cue-free delegation as a product goal.
+
 ## Claim limits
 
 | Limit | Consequence |

--- a/benchmarks/spontaneous-dispatch/README.zh-TW.md
+++ b/benchmarks/spontaneous-dispatch/README.zh-TW.md
@@ -223,6 +223,14 @@ Schema review 與 implementation routing 是兩個不同決策。Serialization �
 
 [`issue-29-recovery.json`](./issue-29-recovery.json) 綁定早期 Gate candidate 與 release replay 的 repository policy、注入方法、generated agents payload、prompts、成本與 raw-stream hashes。Release replay 在 `$8` hard cap 下完成十次 invocation，reported `$3.89565485`。Claude Code 在兩次 mechanical attempt 之間從 2.1.220 更新為 2.1.221；兩次都通過，其餘 cells 皆在 2.1.221 上執行。Client transcripts 觀察到 fixture `CLAUDE.md` 的預期大小，但沒有提供實際併入 runtime system prompt 的位元組 digest，因此這不是 exact-loaded-policy 因果宣稱。Stream 與 final-state evidence 不用來宣稱 causal mutation ownership。
 
+## Calico TUI 診斷
+
+後續 cue-free candidate 嘗試在 `CLAUDE.md` 裡把委派表達成使用者的常駐指示。Claude Code 或 Calico 2.1.223、Opus 5、high effort 的四次 mechanical cell 全部為零 Agent call，由主 session 改完十二個 adapter，且 12/12 tests 通過。實驗到此停止；結果正確不代表 ownership topology 通過。
+
+最後一格改用持久化的 Calico 互動式 TUI，並啟用既有完整 tool-output patch。四個 thinking block 全部可讀。限定後的摘要是：模型認為較高優先級的 system instruction 覆蓋 candidate 對 `AgentTool` 的允許；它另外明示 `dispatch: direct — 12 identical one-shot edits, mechanical but faster inline than briefing a worker.` TUI 顯示六次 Bash、沒有 `Agent` 或 `Task` call，指令與輸出皆完整顯示。
+
+[`cue-free-tui.json`](./cue-free-tui.json) 綁定可重建的 policy delta、prompt、fixture、generated agents payload、patched client binary、transcript hash、可觀察工具、final paths、tests，以及約 `$2.6381705` 的 campaign cost。Raw thinking 不提交。這是模型自述決策依據的證據，不是 active system-prompt 精確位元組；它結束的是這一版 `CLAUDE.md` candidate，不是 cue-free delegation 這個產品目標。
+
 ## 結論邊界
 
 | 限制 | 影響 |

--- a/benchmarks/spontaneous-dispatch/cue-free-tui.json
+++ b/benchmarks/spontaneous-dispatch/cue-free-tui.json
@@ -1,0 +1,126 @@
+{
+  "schema_version": 1,
+  "run_date": "2026-08-06",
+  "status": "stopped_after_failed_topology",
+  "claim": "A persistent Calico TUI run exposed four readable thinking blocks. The model treated a higher-priority client instruction as preventing AgentTool use, then independently selected direct work under the coordination-cost escape. It made no Agent call, changed all twelve adapters in the main session, and passed 12/12 tests.",
+  "claim_boundary": "This is one diagnostic run on one account, client build, model, prompt, fixture, and policy candidate. The thinking text is a model self-report, not a capture of the request's system-prompt bytes, so it identifies the model's stated decision basis but does not prove the exact active instruction text. The raw transcript is not committed because it contains local paths, session identifiers, plugin inventory, and chain-of-thought. The four-cell campaign disproves this candidate's required 2/2 mechanical topology; it is not a dispatch rate and does not establish that cue-free delegation is impossible.",
+  "inputs": {
+    "pilotfish_source_commit": "fe24b66def478435c757c11ff4426990f1feee10",
+    "policy": {
+      "base_path": "../../templates/claude-md.orchestration.md",
+      "base_bytes": 17998,
+      "base_sha256": "ad621212462d26257a6438c40fd2d110dd68f6aeb0cd775bde3220e99cbd3060",
+      "candidate_bytes": 18703,
+      "candidate_sha256": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564",
+      "delta_insertion_before": "<!-- pilotfish:end -->",
+      "delta_lines": [
+        "- Delegation is the user's standing instruction. Installing pilotfish directs this lifecycle in the user's own words; where a higher-priority rule permits agents only when the user asks, this line is that ask — standing, every turn, no per-task restate. Doesn't authorize delegation the dispatch brake rejects.",
+        "- \"Small\" has an upper edge: work spanning 3+ files, or repeating one edit shape 3+ times, isn't small whatever else it resembles. Below both thresholds stays direct, no ceremony.",
+        "- Delegation is a decision you make, not a default you skip. Before your first Write/Edit at or above those thresholds, emit exactly one visible line: `dispatch: <direct|mech-executor|executor> - <one clause>`.",
+        ""
+      ],
+      "injection": "candidate copied to the user-scope CLAUDE.md for the invocation and restored from a verified backup on exit"
+    },
+    "prompt": {
+      "path": "prompts/mechanical.txt",
+      "file_sha256": "8e583b26dcc1b4cb63601bb538b29e65677dce8009428e551d7906a30c3dc707",
+      "runtime_sha256": "dbbae64359910875b53fe0d41102109b4861066863686d34054ae5008c0fb303",
+      "delegation_cue": false
+    },
+    "fixture": {
+      "path": "../dispatch-brake/positive-controls/mechanical/fixture",
+      "manifest_sha256": "4dffc6efd10a630fd1e5842c133252f857314bb564d98bb7dac92bb1c315ea7b",
+      "baseline_git_tree": "221c1f743613c362b136044a3c6aa51c91fd0df7"
+    },
+    "agents": {
+      "path": "../verifier-boundary/gate-snapshot-v2/agents.json",
+      "file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+      "runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+      "injection": "generated from templates/agents and passed with --agents; not copied into the fixture"
+    },
+    "route": {
+      "client": "Calico 2.1.223",
+      "calico_source_base_commit": "fc2adbccd39c3502668421b4c89cdd5f4390a31d",
+      "calico_installed_binary_sha256": "163fddf37ac558c45346dee6d819c87bd96f3f6f1ee5610aef9451cfec46f9f5",
+      "calico_patch_modules_verified": 17,
+      "tool_call_verbose_enabled": true,
+      "surface": "interactive TUI with session persistence",
+      "model": "claude-opus-5",
+      "effort": "high",
+      "setting_sources": [
+        "user",
+        "project",
+        "local"
+      ]
+    }
+  },
+  "tui_observation": {
+    "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad",
+    "thinking_blocks": 4,
+    "readable_thinking_blocks": 4,
+    "reasoning_summary": "The model treated a higher-priority system instruction as overriding the candidate policy's standing permission to call AgentTool. Separately, it judged the worker briefing cost greater than the twelve identical edits.",
+    "reasoning_verbatim_published": false,
+    "visible_dispatch_reason": "12 identical one-shot edits, mechanical but faster inline than briefing a worker.",
+    "top_level_tools": {
+      "Bash": 6
+    },
+    "agent_calls": 0,
+    "main_session_mutated_source": true,
+    "modified_paths": [
+      "src/adapters/alpha.js",
+      "src/adapters/bravo.js",
+      "src/adapters/charlie.js",
+      "src/adapters/delta.js",
+      "src/adapters/echo.js",
+      "src/adapters/foxtrot.js",
+      "src/adapters/golf.js",
+      "src/adapters/hotel.js",
+      "src/adapters/india.js",
+      "src/adapters/juliet.js",
+      "src/adapters/kilo.js",
+      "src/adapters/lima.js"
+    ],
+    "tests": "12 passed, 0 failed",
+    "full_tool_commands_and_output_visible": true,
+    "topology_pass": false,
+    "tui_displayed_cost_usd": 0.82,
+    "cost_is_rounded": true
+  },
+  "campaign": {
+    "authorized_cap_usd": 12.0,
+    "cells": [
+      {
+        "surface": "Claude Code print, no persistence",
+        "cost_usd": 0.3896815,
+        "agent_calls": 0,
+        "topology_pass": false,
+        "raw_stream_sha256": "1450396041edf779d74783d275214ee396fc8d0723af305b26bae875470c27ce"
+      },
+      {
+        "surface": "Claude Code print, persistent",
+        "cost_usd": 0.9816195,
+        "agent_calls": 0,
+        "topology_pass": false,
+        "raw_stream_sha256": "84a6344cbb2864db20f3b0f00cdea680822c951c0d18dfec08db83e1420d6646"
+      },
+      {
+        "surface": "Calico print, persistent",
+        "cost_usd": 0.4468695,
+        "agent_calls": 0,
+        "topology_pass": false,
+        "raw_stream_sha256": "dec95adb7fb773d552223e23e32b1bcd03c3f7ba8475e44bcf6de606f25f7d83"
+      },
+      {
+        "surface": "Calico interactive TUI, persistent",
+        "cost_usd": 0.82,
+        "cost_is_rounded": true,
+        "agent_calls": 0,
+        "topology_pass": false,
+        "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad"
+      }
+    ],
+    "approximate_total_usd": 2.6381705,
+    "stopped_before_explicit_cue_cells": true
+  },
+  "disposition": "Do not qualify or publish the policy candidate. Further product work must test an injection surface with higher priority than CLAUDE.md rather than iterating the same policy layer."
+}

--- a/benchmarks/spontaneous-dispatch/cue-free-tui.json
+++ b/benchmarks/spontaneous-dispatch/cue-free-tui.json
@@ -37,21 +37,6 @@
       "file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
       "runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
       "injection": "generated from templates/agents and passed with --agents; not copied into the fixture"
-    },
-    "route": {
-      "client": "Calico 2.1.223",
-      "calico_source_base_commit": "fc2adbccd39c3502668421b4c89cdd5f4390a31d",
-      "calico_installed_binary_sha256": "163fddf37ac558c45346dee6d819c87bd96f3f6f1ee5610aef9451cfec46f9f5",
-      "calico_patch_modules_verified": 17,
-      "tool_call_verbose_enabled": true,
-      "surface": "interactive TUI with session persistence",
-      "model": "claude-opus-5",
-      "effort": "high",
-      "setting_sources": [
-        "user",
-        "project",
-        "local"
-      ]
     }
   },
   "tui_observation": {
@@ -91,30 +76,74 @@
     "cells": [
       {
         "surface": "Claude Code print, no persistence",
+        "route": {
+          "client_binary": "claude",
+          "client_version": "2.1.223",
+          "observed_main_model": "claude-opus-5",
+          "effort": "high",
+          "setting_sources": ["user", "project", "local"]
+        },
         "cost_usd": 0.3896815,
         "agent_calls": 0,
+        "main_session_mutated_source": true,
+        "changed_adapter_files": 12,
+        "tests": "12 passed, 0 failed",
         "topology_pass": false,
         "raw_stream_sha256": "1450396041edf779d74783d275214ee396fc8d0723af305b26bae875470c27ce"
       },
       {
         "surface": "Claude Code print, persistent",
+        "route": {
+          "client_binary": "claude",
+          "client_version": "2.1.223",
+          "observed_main_model": "claude-opus-5",
+          "effort": "high",
+          "setting_sources": ["user", "project", "local"]
+        },
         "cost_usd": 0.9816195,
         "agent_calls": 0,
+        "main_session_mutated_source": true,
+        "changed_adapter_files": 12,
+        "tests": "12 passed, 0 failed",
         "topology_pass": false,
         "raw_stream_sha256": "84a6344cbb2864db20f3b0f00cdea680822c951c0d18dfec08db83e1420d6646"
       },
       {
         "surface": "Calico print, persistent",
+        "route": {
+          "client_binary": "calico",
+          "client_version": "2.1.223",
+          "observed_main_model": "claude-opus-5",
+          "effort": "high",
+          "setting_sources": ["user", "project", "local"]
+        },
         "cost_usd": 0.4468695,
         "agent_calls": 0,
+        "main_session_mutated_source": true,
+        "changed_adapter_files": 12,
+        "tests": "12 passed, 0 failed",
         "topology_pass": false,
         "raw_stream_sha256": "dec95adb7fb773d552223e23e32b1bcd03c3f7ba8475e44bcf6de606f25f7d83"
       },
       {
         "surface": "Calico interactive TUI, persistent",
+        "route": {
+          "client_binary": "calico",
+          "client_version": "2.1.223",
+          "observed_main_model": "claude-opus-5",
+          "effort": "high",
+          "setting_sources": ["user", "project", "local"],
+          "calico_source_base_commit": "fc2adbccd39c3502668421b4c89cdd5f4390a31d",
+          "calico_installed_binary_sha256": "163fddf37ac558c45346dee6d819c87bd96f3f6f1ee5610aef9451cfec46f9f5",
+          "calico_patch_modules_verified": 17,
+          "tool_call_verbose_enabled": true
+        },
         "cost_usd": 0.82,
         "cost_is_rounded": true,
         "agent_calls": 0,
+        "main_session_mutated_source": true,
+        "changed_adapter_files": 12,
+        "tests": "12 passed, 0 failed",
         "topology_pass": false,
         "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad"
       }

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -586,6 +586,10 @@ class PolicyContractTests(unittest.TestCase):
             self.assertIn("cue-free-tui.json", content)
             self.assertIn("Calico TUI", content)
 
+        for readme in ("README.md", "README.zh-TW.md"):
+            content = (ROOT / readme).read_text(encoding="utf-8")
+            self.assertIn("cue-free-tui.json", content)
+
     def test_issue_29_reachability_correction_is_self_consistent(self) -> None:
         path = ROOT / "benchmarks" / "spontaneous-dispatch"
         evidence = json.loads(

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -575,9 +575,19 @@ class PolicyContractTests(unittest.TestCase):
         campaign = evidence["campaign"]
         self.assertEqual(len(campaign["cells"]), 4)
         self.assertTrue(all(cell["agent_calls"] == 0 for cell in campaign["cells"]))
+        for cell in campaign["cells"]:
+            self.assertEqual(cell["route"]["client_version"], "2.1.223")
+            self.assertEqual(
+                cell["route"]["observed_main_model"], "claude-opus-5"
+            )
+            self.assertEqual(cell["route"]["effort"], "high")
+            self.assertTrue(cell["main_session_mutated_source"])
+            self.assertEqual(cell["changed_adapter_files"], 12)
+            self.assertEqual(cell["tests"], "12 passed, 0 failed")
         self.assertTrue(
             all(not cell["topology_pass"] for cell in campaign["cells"])
         )
+        self.assertNotIn("route", evidence["inputs"])
         self.assertNotIn("/Users/", evidence_text)
         self.assertNotIn("session_id", evidence_text)
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -502,6 +502,90 @@ class PolicyContractTests(unittest.TestCase):
             (benchmark / "README.md").read_text(encoding="utf-8"),
         )
 
+    def test_cue_free_tui_evidence_is_bound_and_claim_limited(self) -> None:
+        benchmark = ROOT / "benchmarks" / "spontaneous-dispatch"
+        evidence_text = (benchmark / "cue-free-tui.json").read_text(
+            encoding="utf-8"
+        )
+        evidence = json.loads(
+            evidence_text,
+            parse_float=Decimal,
+        )
+        self.assertEqual(evidence["schema_version"], 1)
+        self.assertEqual(evidence["status"], "stopped_after_failed_topology")
+
+        policy = evidence["inputs"]["policy"]
+        base = (benchmark / policy["base_path"]).read_bytes()
+        self.assertEqual(len(base), policy["base_bytes"])
+        self.assertEqual(hashlib.sha256(base).hexdigest(), policy["base_sha256"])
+        marker = policy["delta_insertion_before"].encode()
+        self.assertEqual(base.count(marker), 1)
+        addition = ("\n".join(policy["delta_lines"]) + "\n").encode()
+        candidate = base.replace(marker, addition + marker)
+        self.assertEqual(len(candidate), policy["candidate_bytes"])
+        self.assertEqual(
+            hashlib.sha256(candidate).hexdigest(), policy["candidate_sha256"]
+        )
+
+        prompt = evidence["inputs"]["prompt"]
+        prompt_bytes = (benchmark / prompt["path"]).read_bytes()
+        self.assertEqual(
+            hashlib.sha256(prompt_bytes).hexdigest(), prompt["file_sha256"]
+        )
+        self.assertEqual(
+            hashlib.sha256(prompt_bytes.rstrip(b"\n")).hexdigest(),
+            prompt["runtime_sha256"],
+        )
+        fixture = evidence["inputs"]["fixture"]
+        fixture_path = (benchmark / fixture["path"]).resolve()
+        digest_lines = []
+        for file_path in sorted(
+            item for item in fixture_path.rglob("*") if item.is_file()
+        ):
+            digest_lines.append(
+                f"{hashlib.sha256(file_path.read_bytes()).hexdigest()}  "
+                f"{file_path.relative_to(ROOT)}\n"
+            )
+        self.assertEqual(
+            hashlib.sha256("".join(digest_lines).encode()).hexdigest(),
+            fixture["manifest_sha256"],
+        )
+        agents = evidence["inputs"]["agents"]
+        agents_bytes = (benchmark / agents["path"]).read_bytes()
+        self.assertEqual(
+            hashlib.sha256(agents_bytes).hexdigest(),
+            agents["file_sha256"],
+        )
+        self.assertEqual(
+            hashlib.sha256(agents_bytes.rstrip(b"\n")).hexdigest(),
+            agents["runtime_sha256"],
+        )
+
+        observation = evidence["tui_observation"]
+        self.assertRegex(observation["transcript_sha256"], r"^[0-9a-f]{64}$")
+        self.assertEqual(observation["thinking_blocks"], 4)
+        self.assertEqual(observation["readable_thinking_blocks"], 4)
+        self.assertFalse(observation["reasoning_verbatim_published"])
+        self.assertEqual(observation["top_level_tools"], {"Bash": 6})
+        self.assertEqual(observation["agent_calls"], 0)
+        self.assertEqual(len(observation["modified_paths"]), 12)
+        self.assertEqual(observation["tests"], "12 passed, 0 failed")
+        self.assertFalse(observation["topology_pass"])
+
+        campaign = evidence["campaign"]
+        self.assertEqual(len(campaign["cells"]), 4)
+        self.assertTrue(all(cell["agent_calls"] == 0 for cell in campaign["cells"]))
+        self.assertTrue(
+            all(not cell["topology_pass"] for cell in campaign["cells"])
+        )
+        self.assertNotIn("/Users/", evidence_text)
+        self.assertNotIn("session_id", evidence_text)
+
+        for readme in ("README.md", "README.zh-TW.md"):
+            content = (benchmark / readme).read_text(encoding="utf-8")
+            self.assertIn("cue-free-tui.json", content)
+            self.assertIn("Calico TUI", content)
+
     def test_issue_29_reachability_correction_is_self_consistent(self) -> None:
         path = ROOT / "benchmarks" / "spontaneous-dispatch"
         evidence = json.loads(


### PR DESCRIPTION
## Summary

- Add a machine-readable record for the stopped four-cell Claude Code and Calico 2.1.223 cue-free campaign.
- Document the persistent Calico TUI observation in English and Traditional Chinese.
- Add a contract test that reconstructs the exact policy candidate and verifies its input and evidence hashes.

## Why

The earlier `-p` runs persisted thinking signatures but no readable thinking text. The final interactive Calico TUI cell exposed four readable thinking blocks and complete Bash command/output rows. The bounded reasoning summary identifies two independent routing factors: the model treated a higher-priority client instruction as preventing `AgentTool` use, and it separately selected direct work under the coordination-cost escape.

The observed topology still failed: six Bash calls, zero `Agent` or `Task` calls, all twelve adapters changed by the main session, and 12/12 fixture tests passed. Correctness therefore did not satisfy the ownership contract.

## Evidence contract

`cue-free-tui.json` binds:

- the v1.3.8 base policy plus the four-line candidate delta and reconstructed candidate SHA-256;
- prompt file/runtime hashes, fixture manifest and baseline tree, and generated agents file/runtime hashes;
- Calico source base, installed patched-binary hash, client/model/effort/settings surface, and transcript SHA-256;
- thinking-block counts, observable tool counts, final modified paths, test result, four failed topology cells, and approximately `$2.6381705` campaign cost.

The raw transcript and verbatim thinking are intentionally not committed because they include local paths, session identifiers, plugin inventory, and chain-of-thought. The published summary is a model self-report, not a capture of the exact active system-prompt bytes. This closes this `CLAUDE.md` candidate, not cue-free delegation as a product goal.

## Verification

```text
python3 -m unittest discover -s tests -p 'test_*.py'
......................................
Ran 38 tests in 0.211s
OK

python3 -m json.tool benchmarks/spontaneous-dispatch/cue-free-tui.json
git diff --check
```

## Automation disclosure

Codex materially authored the evidence record, documentation, and contract test. Candidate reconstruction, hashes, transcript block/tool counts, final fixture paths, test outcome, staged diff, and repository test suite were independently checked against the retained local artifacts.