### PR TITLE
docs: streamline README navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,7 @@ full plan of changes and get my approval before writing anything.
 
 | Target | Installed change | Reversible |
 |---|---|---|
-| `settings.json` | Adds missing `model` and `fallbackModel` keys; preserves existing choices unless approved | Yes |
+| `settings.json` | Adds missing `model` and `fallbackModel`; conditionally extends an existing `availableModels` allowlist | Restores or removes `model`; `fallbackModel` is removable, while allowlist additions remain unless requested |
 | `agents/` | Eight role-agent files | Yes |
 | `CLAUDE.md` | One versioned `pilotfish:begin/end` policy block | Yes |
 

--- a/README.md
+++ b/README.md
@@ -1,313 +1,163 @@
 # pilotfish 🐟
 
-> Pilot fish swim alongside the ocean's largest predators — small, fast, and doing the routine work so the big one doesn't have to.
+> Small, fast role agents handle volume work while the frontier main session
+> keeps planning, approval, integration, and final judgment.
 
-**pilotfish** is a multi-model orchestration layer for [Claude Code](https://code.claude.com): the `opus` family plans and decides in your main session, Sonnet and Haiku execute the volume work through global subagents, and fresh Opus contexts challenge Plans and completed outcomes. Quality is protected by independent verification, not by using the biggest model everywhere. Everything installs globally — one setup, every project — and the whole stack degrades gracefully when the primary model becomes unavailable.
+**pilotfish** is a global multi-model orchestration policy for
+[Claude Code](https://code.claude.com). New installs use the `opus` family for
+the main session, Sonnet and Haiku for bounded execution and reconnaissance,
+and fresh Opus contexts for risk-triggered review. It installs configuration,
+not a runtime service, and writes nothing into your projects.
 
-> **Want OpenAI GPT-5.6 inside Claude Code without changing native Claude state?** [remora](https://github.com/Nanako0129/remora-cc) packages pilotfish's role-based orchestration pattern into a session-scoped launcher for an existing Anthropic-compatible gateway. Use pilotfish to study or customize the global policy; use remora for an approval-gated, verifiable install whose model and gateway overrides disappear with the child process.
-
-> **Want the same orchestration on Grok Build?** [pilotfish-grok](https://github.com/Nanako0129/pilotfish-grok) ports the role lifecycle and capability boundaries to `~/.grok/` (agents, roles, and a model-free policy). Use this repo for Claude Code; use pilotfish-grok when the host is Grok Build — separate install surface, does not write `~/.claude/`.
-
-**Where this came from:** my weekly quota reset one morning, and the first thing I did with a fresh Fable 5 allowance was ask it to figure out why the previous week's had evaporated. This repo is the setup that research produced, and it's what I now run daily on every project — three config files, no runtime code. The research notes (with sources) are in [docs/](./docs/).
-
-[繁體中文說明](./README.zh-TW.md)
+[繁體中文](./README.zh-TW.md)
 
 ## Contents
 
 - [Why](#why)
 - [How it works](#how-it-works)
 - [Install](#install)
-- [Trust & security](#trust--security)
-- [What gets installed](#what-gets-installed)
-- [Updating](#updating)
-- [The fallback story](#the-fallback-story)
-- [Tuning & FAQ](#tuning--faq)
-- [Research & design](#research--design)
-- [Contributing](#contributing)
-- [Uninstall](#uninstall)
-- [Support pilotfish](#support-pilotfish)
-- [License](#license)
+- [Operate](#operate)
+- [Documentation](#documentation)
+- [Project](#project)
 
 ## Why
 
-On 2026-07-24, Anthropic released [Opus 5](https://www.anthropic.com/news/claude-opus-5), describing it as close to Fable 5 intelligence at half the API price. Opus 5 leads many of Anthropic's published evaluations, but not every one. pilotfish therefore defaults **new installs** to the `opus` family alias and keeps Fable 5 as an explicit `/model fable` opt-in. This is a cost-aware default, not a claim that Opus 5 is universally better; the decision and rollback criteria are tracked in [#23](https://github.com/Nanako0129/pilotfish/issues/23).
+Most coding-session tokens are spent on search, repetitive edits, tests, and
+documentation rather than frontier judgment. pilotfish routes those bounded
+paths to cheaper roles while keeping the main session accountable and using
+fresh-context reviewers at material acceptance boundaries.
 
-The original July research still explains the architecture: frontier-model sessions are expensive, while most coding-session tokens are searching, mechanical edits, test runs, and doc updates rather than judgment. Those high-volume paths can use Sonnet or Haiku while acceptance-boundary reviews use a fresh Opus context.
+New installs default to the `opus` alias; Fable remains an explicit
+`/model fable` choice. This is a cost-aware default, not a claim that one model
+wins every task. The rationale and measurements live in
+[research](./docs/research.md), the [design notes](./docs/design.md), and
+[#23](https://github.com/Nanako0129/pilotfish/issues/23).
 
-Every piece of this now carries Anthropic backing. The [Fable 5 prompting guide](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5) recommends frequent subagent delegation and notes that **independent fresh-context verifier subagents outperform self-critique**. And as of 2026-07-08, the cheap-executor split is officially benchmarked: Anthropic's own tests put a **Fable 5 orchestrator with Sonnet 5 workers at 96% of all-Fable performance for 46% of the cost** (BrowseComp: 86.8% vs 90.8% accuracy, $18.53 vs $40.56 per problem), with the inverse advisor pattern (Sonnet executor consulting Fable) at ~92% for ~63% on SWE-bench Pro — the orchestrator split pilotfish uses won on both axes ([multi-agent docs](https://platform.claude.com/docs/en/managed-agents/multi-agent)). A community experiment points the same direction at hobby scale — a delegation-heavy 12-worker audit ([Developers Digest](https://www.developersdigest.tech/blog/fable-5-orchestrator-model-playbook)), best-case-shaped, in API dollars:
-
-| Setup (12-worker audit experiment, Developers Digest) | Cost | Savings |
-|---|---|---|
-| Everything on Fable 5 | $14.50 | — |
-| Fable 5 orchestrates + Sonnet workers | $6.10 | 58% |
-| Fable 5 orchestrates + Haiku workers | $3.70 | 74% |
-
-Two subscription-specific bonuses stack on top:
-
-> **Tip:** Claude subscriptions use a two-bucket weekly limit ([official article](https://support.claude.com/en/articles/14552983-models-usage-and-limits-in-claude-code)) — a shared "all models" bucket plus an **additional Sonnet-only bucket**. Routing execution to Sonnet subagents costs less per token *and* draws on that extra dedicated headroom. (Sonnet usage still counts against the all-models bucket too — it's additional allowance, not a fully separate pool.)
-
-> ⚠️ **Warning:** Since Claude Code v2.1.198 the built-in `Explore` subagent inherits your main-session model. If your main session runs Fable 5 or Opus, every background search burns Opus-tier tokens (the Claude API caps Explore's inherited model at Opus; third-party platforms have no cap). pilotfish overrides it back to Haiku. (Trade-off, stated openly: a custom Explore loads your user memory like any subagent, which the built-in skips — the policy block self-disables for subagent roles to keep that overhead small.)
-
-> **Note:** The two bullets above are subscription-plan mechanics. On the pay-per-token API the per-token savings still apply (there is no weekly bucket). Model aliases remain provider-, account-, and settings-dependent: the recorded clean first-party Gate resolved `opus` to Opus 5, while the same client with its user setting source loaded resolved it to Opus 4.8. Use a full model ID or the platform's `ANTHROPIC_DEFAULT_*_MODEL` environment variable when an exact deployment matters.
+| Host or use case | Project |
+|---|---|
+| Claude Code global policy | This repository |
+| Claude Code with session-scoped GPT routing | [remora](https://github.com/Nanako0129/remora-cc) |
+| Grok Build | [pilotfish-grok](https://github.com/Nanako0129/pilotfish-grok) |
+| Codex CLI | [pilotfish-codex](https://github.com/miyago9267/pilotfish-codex) |
 
 ## How it works
 
-Three layers, three files' worth of configuration, all under `~/.claude/`:
-
-> **Configuration root:** these paths assume the default. If you set [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars), every `~/.claude/` path below lives under that directory instead, and the installer resolves it in Step 0 of the [runbook](./install/AGENT-INSTALL.md).
-
-> ⚠️ **A successful install does not guarantee automatic delegation. Add an explicit opt-in when you need the lifecycle.**
-> Higher-priority Claude Code instructions can suppress Agent dispatch, and a
-> user-level `CLAUDE.md` cannot override them. This is not confined to one plan.
-> On a first-party Pro account running Claude Code 2.1.220, two cue-free schema
-> attempts dispatched nothing. On the same machine and client after an upgrade to
-> Max, a four-cell baseline reached the expected topology on **one positive attempt
-> out of four** — the twelve-file mechanical cell failed both attempts with the main
-> session rewriting every file itself. Dispatch was observed on Max and not on Pro,
-> but the two are not a ranking: the cells differ, the repository tree changed
-> alongside the plan, and a handful of attempts is not a rate. There are two separate
-> injections with different gates; the subscription-gated one was observed absent on
-> Max while the session-guidance one remained. Neither plan reliably dispatches.
-> When you want the orchestration lifecycle, add
-> `Use pilotfish. Follow its dispatch brake: keep direct work in the main session and call the named agents only when the policy selects delegation.` to the request.
-> The historical Pro explicit arm reached `scout`, `plan-verifier`,
-> `mech-executor`, and `verifier`. The current Max recovery matrix reached
-> `plan-verifier`, `mech-executor`, and `verifier` while keeping routine docs and a
-> single unknown bug direct; it did not exercise the other roles. This is not
-> attributed to prompt compression: the unchanged v1.3.3
-> cue-free control recorded zero dispatch alongside the v1.3.4 compressed
-> candidate. Per-cell evidence, including what "cue-free" does and does not mean
-> in those records, is in
-> [`benchmarks/spontaneous-dispatch`](./benchmarks/spontaneous-dispatch/README.md).
-> A later Calico 2.1.223 TUI attempt also stayed direct. Four readable thinking
-> blocks exposed the model's stated decision basis; the bounded evidence and its
-> claim limits are in [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json).
-> Tracking: [#29](https://github.com/Nanako0129/pilotfish/issues/29).
-
-<details>
-<summary><b>What the mechanism is</b> — two independent injections, and what we can and cannot claim about them</summary>
-
-Two different injections have been discussed as if they were one. Both were read out of official Claude Code builds under `~/.local/share/claude/versions/`, and every claim here is anchored to a string you can search for yourself rather than to a byte offset.
-
-| | this repo's report | the other one |
+| Layer | Installed target | Responsibility |
 |---|---|---|
-| site | Agent tool description | system prompt section, flag name `tengu_heron_brook` |
-| text | `Do not spawn agents unless the user asks.` … `it's the expensive path on this plan.` | `Do not call the AgentTool unless the user requested it` |
-| gate | a subscription-type comparison against `"pro"`, inline in the tool-description builder, with no override in that expression | resolver `dMy`, three ordered sources — see below |
-| tracked in | [#29](https://github.com/Nanako0129/pilotfish/issues/29) | [Serhii-Leniv/claude-router#55](https://github.com/Serhii-Leniv/claude-router/issues/55), [anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988) |
+| Machine | `~/.claude/settings.json` | Main-model alias and fallback chain |
+| Roles | `~/.claude/agents/*.md` | Model, effort, and capability boundary for each role |
+| Policy | `~/.claude/CLAUDE.md` | Dispatch, approval, verification, and long-run behavior |
 
-The second one is a **string-valued** section, not a boolean one. In 2.1.220, `dMy` resolves its content from client data, then a flag lookup, then a built-in default; the first two sources can supply arbitrary text. The `opus_5_prompt_bundle` capability check and its killswitch live in `tXn`, which gates **only** the built-in-default branch.
-
-Three separate string searches across the official builds we retain:
-
-| official build | tool-description paragraph | `tengu_heron_brook` identifier | built-in default payload |
-|---|---|---|---|
-| 2.1.218 | present | present (7×) | absent |
-| 2.1.219 | present | present | present |
-| 2.1.220 | present | present | present |
-
-**Claim boundary.** A string present in a binary is not an instruction active in a session, and three builds cannot establish when anything was introduced upstream — [anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988) is the source for that side of it. We found no documented user-facing setting that opts in persistently, and we do not claim none exists; that needs CLI and settings evidence we have not gathered. As corroboration only, from our own repackaging of Claude Code native builds, [Calico](https://github.com/Nanako0129/calico-claude): the tool-description paragraph is present in all ten retained builds between 2.1.207 and 2.1.220 — a non-contiguous set, not every release in that range.
-
-**Diagnostic, not proof.** Asking a fresh session to describe its delegation policy can reveal the model's own account of the constraint. The later Calico 2.1.223 TUI diagnostic persisted four readable thinking blocks and showed the model treating a higher-priority instruction as preventing AgentTool use. This is behavioral evidence, not the exact active system-prompt bytes; see [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json).
-
-**If you also run [claude-router](https://github.com/Serhii-Leniv/claude-router):** do not enable `forceRoute` while pilotfish is installed. It overrides the model each agent sets in its own frontmatter, which is exactly how pilotfish gives `verifier` a fresh Opus context; an Opus-pinned role was observed running on `claude-sonnet-5`. That tool's `restoreDelegation` option strips the second injection above.
-
-</details>
-
-| Layer | File(s) | Job |
-|---|---|---|
-| Machine | `~/.claude/settings.json` | Who orchestrates (`opus`) + automatic `fallbackModel` chain |
-| Roles | `~/.claude/agents/*.md` | Eight role agents, each pinned to the right model tier and capability surface via frontmatter |
-| Policy | `~/.claude/CLAUDE.md` | *How* to delegate — written in terms of roles, never model names |
+If `CLAUDE_CONFIG_DIR` is set, all `~/.claude/` paths above move under that
+configuration root.
 
 ```mermaid
 flowchart TD
-    U[You] --> O
+    U["You"] --> O
     subgraph MAIN["main session — opus family alias"]
-        O["Orchestrator<br>plan / decide / spec / review"]
+        O["Orchestrator
+plan / decide / spec / review"]
     end
-    O -->|recon| S["scout / Explore<br>haiku · effort low"]
-    O -->|Plan challenge| PV["plan-verifier<br>opus · read-only"]
+    O -->|recon| S["scout / Explore
+haiku · effort low"]
+    O -->|Plan challenge| PV["plan-verifier
+opus · read-only"]
     PV -->|READY / REVISE| O
-    O -->|mechanical spec| M["mech-executor<br>sonnet · effort low"]
-    O -->|judgment work| E["executor<br>sonnet · effort medium"]
-    O -->|security evidence| SR["security-reviewer<br>opus · read-only"]
+    O -->|mechanical spec| M["mech-executor
+sonnet · effort low"]
+    O -->|judgment work| E["executor
+sonnet · effort medium"]
+    O -->|security evidence| SR["security-reviewer
+opus · read-only"]
     SR --> O
-    O -->|approved security work| SEC["security-executor<br>opus · effort high"]
-    M --> V["verifier<br>opus · fresh context"]
+    O -->|approved security work| SEC["security-executor
+opus · effort high"]
+    M --> V["verifier
+opus · fresh context"]
     E --> V
     SEC --> V
     V -->|CONFIRMED / REFUTED / INCONCLUSIVE| O
 ```
 
-The eight roles:
-
-| Role | Model | Effort | Used for |
+| Role | Model | Effort | Purpose |
 |---|---|---|---|
-| `scout` | haiku | low | Read-only lookups: "where/how is X", symbol usages, config values |
-| `Explore` | haiku | low | Overrides the built-in Explore agent (see warning above) |
-| `plan-verifier` | opus | medium | Read-only review of one Plan envelope or slice; returns bare `READY` or structured `REVISE` |
-| `security-reviewer` | opus | high | Tool-enforced read-only security evidence and threat review before approval |
-| `mech-executor` | sonnet | low | Fully-specified mechanical work: pattern refactors, convention tests, docs, bulk edits |
-| `executor` | sonnet | medium | Implementation needing judgment: features, bug fixes, design-sensitive refactors |
-| `verifier` | opus | medium | Fresh-context calibrated outcome verification; returns CONFIRMED/REFUTED/INCONCLUSIVE and never fixes |
-| `security-executor` | opus | high | Approved security implementation — deliberately kept off Fable 5, whose safety classifiers can refuse benign defensive-security work |
+| `scout` | haiku | low | Read-only repository reconnaissance |
+| `Explore` | haiku | low | Broad read-only search without inheriting the main model |
+| `plan-verifier` | opus | medium | Pre-approval Plan challenge: `READY` or structured `REVISE` |
+| `security-reviewer` | opus | high | Read-only security evidence before approval |
+| `mech-executor` | sonnet | low | Fully specified mechanical repetition |
+| `executor` | sonnet | medium | Approved implementation requiring local judgment |
+| `verifier` | opus | medium | Fresh-context outcome falsification after implementation |
+| `security-executor` | opus | high | Approved security-sensitive implementation |
 
-`executor` moved from Opus to Sonnet ([#18](https://github.com/Nanako0129/pilotfish/issues/18)) so the default delegated implementation path stays below the Opus main session. This is a targeted routing fix, not a rule that every role must differ from the main-session tier. The four Opus-only roles stay put: `verifier` and `plan-verifier` provide fresh-context challenge at acceptance boundaries, while `security-reviewer` and `security-executor` carry a correctness-over-cost mandate. Same-tier delegation provides no tier saving, but it can still provide independent context, capability isolation, or concurrency. An installer profile that swaps tiers by detected main-session model was considered and rejected — see [Deliberately left out](./docs/design.md#deliberately-left-out).
+Small, stable work stays in the main session. Larger work is split only when a
+bounded role has a stable contract and delegation has positive net benefit.
+Risk, not file count, triggers independent review. The exact lifecycle is
+defined in the [policy template](./templates/claude-md.orchestration.md) and
+explained in the [design rationale](./docs/design.md).
 
-The policy layer uses phase-specific dispatch brakes. Small, stable work stays direct. Large work keeps shared constraints in a program envelope and splits only genuinely independent execution slices. Independent review is triggered by concrete security, irreversible/external, data, release, or cross-component acceptance risk—not by file count or “non-trivial” alone. After two automatic `REVISE` verdicts, the main session stops automatic resubmission, dispositions each blocker as `FIX`, `DEFER`, or `REJECT`, and continues independently approvable slices. A material fix, narrowing/split, or evidence-backed disposition that changes the readiness claim gets one final fresh check; a further `REVISE` pauses or escalates instead of reopening the loop. It asks the user only for unresolved high-impact or product/authority decisions.
+> ⚠️ **Automatic delegation is not guaranteed.** Higher-priority Claude Code
+> instructions can suppress Agent dispatch, and user-level `CLAUDE.md` cannot
+> override them. When the lifecycle matters, include the following request.
 
-| Phase | pilotfish behavior |
-|---|---|
-| Discovery | `scout` / `Explore` collect bounded facts under a stable research contract; the implementation outcome may still be unknown |
-| Plan | Main session owns the envelope and slices; risk-triggered `plan-verifier` review covers one stable unit and returns bare `READY` or structured `REVISE` |
-| Approval | Large, architectural, risky, or explicitly plan-first work waits for explicit approval before source writes or implementation briefs |
-| Execution | `mech-executor`, `executor`, or `security-executor` receives one stable, exclusively owned contract |
-| Verification | For risk-triggered work, `verifier` independently tests the exact completed-work claim through read-and-run tools; main session keeps final judgment |
+```text
+Use pilotfish. Follow its dispatch brake: keep direct work in the main session
+and call the named agents only when the policy selects delegation.
+```
 
-Before likely long autonomous work, the main session announces `AUTO` or `ASK`; `/goal` preserves the objective but grants no authority. `AUTO` stays inside approved reversible scope, while `ASK` pauses through native input or `PAUSED_NEEDS_USER`. P0 freezes the affected slice; P1 must be fixed or paused. Normal verification is one complete pass plus one targeted recheck of a reproduced blocker; five materially changed passes remain only an emergency ceiling for high-risk P1/P2 recovery.
-
-Stable multi-file mechanical repetition with a complete one-shot brief, exclusive ownership, and per-item acceptance defaults to exactly one `mech-executor` before main-session edits; only a concrete blocker named before editing rebuts that default, while the main session owns per-item triage, exceptions, integration, and acceptance.
-
-Long-running processes remain main-session owned. Every Bash-capable leaf role (`mech-executor`, `executor`, `verifier`, `security-executor`) runs bounded commands in the foreground and never detaches with `nohup`, `setsid`, trailing `&`, or subagent-side background execution; if work cannot finish within 10 minutes, it returns the exact command, absolute worktree or working directory, required environment, and input paths to the orchestrator. The orchestrator runs it in that same context, never implicitly from the parent checkout. Any agent likely to run a long command must itself be spawned with `run_in_background: true`, preserving harness tracking and completion notification.
+The bounded results and claim limits are recorded in the
+[spontaneous-dispatch benchmark](./benchmarks/spontaneous-dispatch/README.md)
+and [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json).
+They are behavioral observations, not a dispatch rate or proof of the active
+system-prompt bytes.
 
 ## Install
 
-The recommended path is to clone the pinned v1.3.8 release locally, then start Claude Code from that checkout so it can read the runbook as a local file:
+Clone the reviewed release, start Claude Code from that checkout, and ask it to
+follow the local runbook:
 
-```sh
+```bash
 git clone --branch v1.3.8 --depth 1 https://github.com/Nanako0129/pilotfish.git
 cd pilotfish
 claude
 ```
 
-In that Claude Code session, paste this prompt:
-
 ```text
-Read the local file install/AGENT-INSTALL.md in the current checkout and follow it to install pilotfish into my global Claude Code configuration.
-Show me the full plan of changes and get my approval before writing anything.
+Read the local file install/AGENT-INSTALL.md in the current checkout and follow
+it to install pilotfish into my global Claude Code configuration. Show me the
+full plan of changes and get my approval before writing anything.
 ```
 
-Claude reads the local install runbook, inspects your existing configuration, shows you a merge plan (nothing is overwritten blindly), and applies it after you approve. Installation is idempotent — running it again upgrades in place.
+> **Runtime requirement:** Claude Code **2.1.219 or newer**. Restart Claude Code
+> after installation so the agent directory and model setting are reloaded.
 
-> **Runtime requirement:** Claude Code **2.1.219 or newer**. This is pilotfish's tested floor for Opus 5-aware alias routing and is newer than its verified agent-`tools` enforcement baseline; it does not guarantee one exact backend for every provider, account, or settings stack. The installer stops before making changes on an older or unidentifiable build. On native Windows without WSL, the runbook's shell snippets assume a POSIX shell; the installing agent is instructed to fall back to its own file tools. Restart your session afterwards: the agents directory is scanned at session start, and the `model` setting applies on restart.
+> ⚠️ **Trust boundary:** the policy loads into every future session. Review the
+> pinned checkout, the [agent templates](./templates/agents/), the
+> [policy template](./templates/claude-md.orchestration.md), and the
+> [install runbook](./install/AGENT-INSTALL.md) before approving writes. Do not
+> bypass WebFetch prompt-injection protection to install from a mutable raw URL.
 
-For convenience, you can also paste the raw GitHub prompt below. This is a mutable, unpinned convenience path: it follows `main`, so the runbook and templates may change independently between review and installation, and Claude Code's WebFetch prompt-injection protection may intercept a remote document that directly instructs an AI to install software. If it is intercepted, use the local-checkout path above; do not disable or bypass the safety check.
-
-```text
-Read https://raw.githubusercontent.com/Nanako0129/pilotfish/main/install/AGENT-INSTALL.md
-and follow it to install pilotfish into my global Claude Code configuration.
-Show me the full plan of changes and get my approval before writing anything.
-```
-
-Prefer to do it by hand? The same steps are written for humans in [install/AGENT-INSTALL.md](./install/AGENT-INSTALL.md), and every file it installs lives under [templates/](./templates/).
-
-## Trust & security
-
-pilotfish installs by having Claude read a runbook and template files from this repo and merge them into your global `~/.claude/` config — including a policy block that then loads into **every future session**. Treat it like any `curl | sh`: trust flows from this repo and your GitHub connection, not from the paste. The local checkout path is recommended because you can inspect the pinned release before Claude reads the runbook. Before running it:
-
-- **Read the actual bytes that get installed**, not just the runbook: the eight files in [templates/agents/](./templates/agents/) and [templates/claude-md.orchestration.md](./templates/claude-md.orchestration.md). Nothing else is written to disk.
-- **Pin to a release tag or commit** so what you reviewed is what installs — `main` can change between the moment you read it and the moment Claude reads it. The recommended command above pins to the `v1.3.8` release tag; for the strictest guarantee, fetch and check out the full commit SHA you reviewed, then verify that checkout before launching Claude.
-- **Keep the approval gate:** Claude writes nothing until you approve the merge plan, but the plan is still a summary of the runbook. Review the local runbook and templates yourself, and do not weaken or bypass WebFetch's prompt-injection protection if the raw URL is intercepted.
-
-## What gets installed
-
-> **Configuration root:** these paths assume the default. If you set [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars), every `~/.claude/` path below lives under that directory instead, and the installer resolves it in Step 0 of the [runbook](./install/AGENT-INSTALL.md).
-
-| Target | Change | Reversible |
+| Target | Installed change | Reversible |
 |---|---|---|
-| `~/.claude/settings.json` | For a missing key, sets `model` → `"opus"` and `fallbackModel` → `["sonnet"]`; preserves existing choices unless you approve a change; if `availableModels` already restricts selection, keeps `opus`, `fable`, `sonnet`, and `haiku` selectable | Yes — keys are independent |
-| `~/.claude/agents/` | Eight role agent files (listed above) | Yes — delete the files |
-| `~/.claude/CLAUDE.md` | One `## Orchestration` section between `<!-- pilotfish:begin/end -->` markers | Yes — remove the marker block |
+| `settings.json` | Adds missing `model` and `fallbackModel` keys; preserves existing choices unless approved | Yes |
+| `agents/` | Eight role-agent files | Yes |
+| `CLAUDE.md` | One versioned `pilotfish:begin/end` policy block | Yes |
 
-Nothing is written into any project. That's deliberate — see the design doc.
+The installer is idempotent and shows a merge plan before writing. Human-readable
+steps, backups, collision handling, verification, updates, and uninstall are all
+in [install/AGENT-INSTALL.md](./install/AGENT-INSTALL.md).
 
-## Updating
+## Operate
 
-The installer is idempotent, so **re-running the install prompt is the update** — unchanged files are skipped, the policy block is replaced in place, your settings are only touched if keys are missing. For a pinned update, first obtain the release tag you want to upgrade to, clone that tagged checkout locally, and start Claude Code from it:
-
-```sh
-git clone --branch <RELEASE_TAG> --depth 1 https://github.com/Nanako0129/pilotfish.git
-cd pilotfish
-claude
-```
-
-If you require a full commit SHA instead, fetch and check out that SHA before starting Claude Code.
-
-Then paste:
-
-```text
-Read the local file install/AGENT-INSTALL.md in the current checkout and follow its "Updating an existing install" section: detect my installed pilotfish version, show me the changelog since then, and upgrade after my approval.
-```
-
-The raw `main` prompt in [Install](#install) remains a mutable convenience path, not a pinned or reliable update path; it may be intercepted by WebFetch prompt-injection protection, and it must not be used to bypass that protection.
-
-| Want to… | How |
+| Task | Where to go |
 |---|---|
-| Check what you have installed | `CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; grep -o "pilotfish v[0-9.]*" "$CFG/CLAUDE.md"` — no output with markers present = pre-v1.1.0, update recommended |
-| Get notified of new releases | GitHub → **Watch → Custom → Releases** on this repo |
-| See what changed | [CHANGELOG.md](./CHANGELOG.md) — every release is also a git tag |
-| Stay frozen on a reviewed version | Install pinned to a tag or SHA (see [Trust & security](#trust--security)); pinned installs never move until you re-pin |
+| Tune models, effort, delegation, or managed settings | [Usage guide](./docs/usage.md) |
+| Update an existing install | [Runbook: Updating an existing install](./install/AGENT-INSTALL.md#updating-an-existing-install) |
+| Review release changes | [CHANGELOG.md](./CHANGELOG.md) |
+| Disable pilotfish for one project | Use a separate `CLAUDE_CONFIG_DIR`; details are in the [usage guide](./docs/usage.md#disable-update-or-uninstall) |
+| Uninstall safely | [Runbook: Uninstall](./install/AGENT-INSTALL.md#uninstall) |
 
-## The fallback story
-
-This section is about the stack staying *functional* when the primary model disappears, not about staying *cheap*. New installs use the `opus` family alias so provider version changes do not require policy edits, plus a Sonnet fallback for transient primary-model failures. No policy text names a model, so role routing remains isolated in agent frontmatter:
-
-| Failure mode | What catches it | Your action |
-|---|---|---|
-| Primary Opus overloaded / unavailable | `fallbackModel: ["sonnet"]` switches automatically with a notice | None |
-| A tier gets deprecated (Opus 4.8 → 4.9, Sonnet 5 → next) | Role agents use aliases (`opus`, `sonnet`, `haiku`) that track the recommended version | None |
-| An opted-in Fable session refuses a security task mid-run | Security work is pre-routed to `security-executor` (Opus), so it never reaches Fable's classifier | None |
-| The default delegated implementation path collapses onto the Opus main loop | `executor` stays on Sonnet | Re-point `executor`'s `model:` line if your environment overrides its tier |
-
-The delegation policy in `CLAUDE.md` speaks only of roles (`executor`, `scout`, …). Model bindings live in exactly one place — one line of frontmatter per agent file — so re-pointing a tier is a one-line edit that takes effect everywhere.
-
-## Tuning & FAQ
-
-| Question | Answer |
-|---|---|
-| I want to save even more quota | Switch the main session to `/model opusplan` — Opus handles planning turns and Sonnet handles the main session's execution turns. This is a main-session model switch, separate from subagent routing: every role agent still uses its own frontmatter binding. Moving `executor` to Sonnet ([#18](https://github.com/Nanako0129/pilotfish/issues/18)) prevents that default implementation role from escalating an Opus-main-loop fallback back onto Opus; the four explicitly Opus-bound review and security roles remain unchanged. |
-| Why does `executor` use Sonnet while `verifier` stays on Opus? | `executor` is the default volume implementation path, so Sonnet preserves a lower-cost tier below the Opus main session. `verifier`, `plan-verifier`, `security-reviewer`, and `security-executor` remain on Opus for their acceptance-boundary or security responsibilities. A same-tier role call is not automatically useless: fresh context, enforced tool boundaries, and independent review can still justify it. The change in [#18](https://github.com/Nanako0129/pilotfish/issues/18) claims only the routing distinction and tier saving for the default implementation path; no role-specific Opus-versus-Sonnet executor benchmark has been run. |
-| Can I force every subagent onto one model? | `CLAUDE_CODE_SUBAGENT_MODEL` overrides *all* per-agent frontmatter — that's why pilotfish doesn't set it. Leave it unset unless you want a temporary global override. |
-| I use `availableModels` as an allowlist | Then it must contain every alias the agents use (`opus`, `sonnet`, `haiku`), or those agents silently fall back to inheriting the main-session model. The installer checks this. |
-| Why `effort: low` on the cheap roles? | Effort is the second big quota lever. Fable-5-generation models at low effort routinely match previous-generation `xhigh`; recon and mechanical work don't need deep thinking. |
-| Which effort for the main session? | Start with `high` for judgment-heavy orchestration and lower it when quota or latency matters more. If you opt into Fable, follow its model-specific prompting guidance. |
-| How do I request a 1M context window? | The plain `opus` alias follows the provider default. If you need to request 1M explicitly on a supported provider, set `model` to `"opus[1m]"`; pilotfish leaves an existing choice untouched. |
-| Does the orchestrator ever do work itself? | Yes — quick reads, small bounded repository scans, decisions, root-cause exploration, trace-driven debugging, tightly coupled state work, and anything you explicitly asked *it* to judge. Other work is delegated when its combined cost, context, latency, isolation, or verification benefit exceeds reconstruction and integration overhead. |
-| My project has its own CLAUDE.md — conflict? | No project file is ever touched: pilotfish writes only under the Claude Code configuration root (`~/.claude/` by default; `CLAUDE_CONFIG_DIR` overrides it). At runtime Claude Code *stacks* project memory and user memory. A repo-local instruction can keep optional execution inline, but mandatory risk review remains active. For a full repo-specific opt-out, launch that repo with a separate `CLAUDE_CONFIG_DIR` whose `CLAUDE.md` has no pilotfish block. |
-| I also installed a delegation-planning skill | Treat it as a complementary planning layer. A skill such as [Baton](https://github.com/cablate/baton) can shape discovery questions, worker count, ownership, sequence, and stop conditions; pilotfish supplies the named Claude roles, model routing, leaf-agent boundary, approval gate, and verifier contract. The [compatibility Gates](./benchmarks/baton-compatibility/README.md) record the v1.3.2 envelope → current-slice → approved execution → `CONFIRMED` lifecycle, including an Opus 5 rerun whose disclosed post-verdict edit required a third corrective verification invocation. The [prompt-neutral activation Gate](./benchmarks/baton-dispatch-effect/README.md) separately covers four-scout dispatch under v1.3.1. These are bounded compatibility and reachability observations, not efficiency or frequency claims. pilotfish never disables user skills. |
-| Subagent quality worries me | Risk-triggered `plan-verifier` and outcome `verifier` calls provide fresh evidence; their verdicts do not replace main-session judgment. `REVISE` reports all known P0-P2 blockers in one pass, while P3/P4 remain advisory. The main session dispositions every finding as `FIX`, `DEFER`, or `REJECT`; normal verification is one full pass and, after a reproduced fix, one targeted recheck. |
-| Doesn't spawning agents cost extra? | Yes — every spawn is a fresh context that re-reads its slice of the codebase, and synthesis costs main-session tokens. A bounded task-local scan therefore stays inline by default. Discovery may still fan out when disjoint evidence materially reduces Plan uncertainty, while execution delegates only after its contract is stable. In the public mechanical control's execution-only segment, delegation reported 36.01% less cost with a 7.92% wall-time trade-off; neither compared run included the required outcome verifier, so this demonstrates route reachability rather than full-lifecycle savings. The research fixture shows the overhead of two scouts on one small task, not that plan-first discovery is categorically wrong. |
-| Turn it off fast? | "Work inline" disables optional execution delegation only; mandatory risk review still applies. **Full opt-out:** comment out the `pilotfish:begin/end` block in the `CLAUDE.md` under the configuration root resolved by Step 0 of the [runbook](./install/AGENT-INSTALL.md), then start a new session. For one repo only, use a separate `CLAUDE_CONFIG_DIR` without that block. The agent files may remain installed and unused. |
-| Managed / enterprise machine? | Managed settings outrank user settings: a managed `model`, `availableModels` allowlist, or a managed agent with the same name will override pilotfish's user-level install. If roles don't take effect after restart, ask your admin — pilotfish can't (and shouldn't) override managed policy. |
-
-## Research & design
-
-This repo is the packaged result of a sourced research pass (official docs, Anthropic announcements, community measurements) plus a design rationale. Host ports that reuse the same orchestration idea live elsewhere: [pilotfish-grok](https://github.com/Nanako0129/pilotfish-grok) for Grok Build, [pilotfish-codex](https://github.com/miyago9267/pilotfish-codex) for Codex CLI, and [remora](https://github.com/Nanako0129/remora-cc) for session-scoped GPT routing inside Claude Code.
-
-| Document | Language | Contents |
-|---|---|---|
-| [docs/research.md](./docs/research.md) | English | Full research findings: Fable 5 strengths & when it's wasteful, subscription economics, official Claude Code mechanisms, community measurements — with sources |
-| [docs/research.zh-TW.md](./docs/research.zh-TW.md) | 繁體中文 | 研究報告原版（the original the English version translates） |
-| [docs/design.md](./docs/design.md) | English | Why three layers, why role-based policy, why aliases over pinned IDs, effort tiering, what was deliberately left out |
-| [benchmarks/dispatch-brake/README.md](./benchmarks/dispatch-brake/README.md) | English + data | Reproducible negative/positive controls, rejected policy iterations, Agent traces, cost and timing evidence |
-| [benchmarks/dispatch-brake/positive-controls/README.md](./benchmarks/dispatch-brake/positive-controls/README.md) | English + data | Mechanical delegation evidence plus the measured task-local overhead and interpretation limits of small read-only fan-out |
-| [benchmarks/spontaneous-dispatch/README.md](./benchmarks/spontaneous-dispatch/README.md) | English + data | Cue-free Opus baseline, v1.3.1 mechanical/bug topology gates, sanitized traces, and Fable credit-gate disclosure |
-| [benchmarks/baton-dispatch-effect/README.md](./benchmarks/baton-dispatch-effect/README.md) | English + data | Prompt-neutral activation matrix: bounded no-activation observation plus a four-domain Gate with Baton activation, four completed scouts, exclusive ownership, full collection, and output-shape correctness |
-| [benchmarks/baton-compatibility/README.md](./benchmarks/baton-compatibility/README.md) | English + data | Historical exact-byte native-Claude two-turn lifecycle plus the Opus 5 rerun and its corrective third invocation, exact prompts, rejected routing evidence, and machine-readable results |
-| [benchmarks/prompt-compression/README.md](./benchmarks/prompt-compression/README.md) | English + data | v1.3.4 prompt byte reduction, runtime context census, exact candidate hashes, paid behavioral observations, and current claim limits |
-| [benchmarks/verifier-boundary/README.md](./benchmarks/verifier-boundary/README.md) | English + data | v1.3.7 exact-byte native-Claude schema lifecycle and routine-docs control, including failed attempts, role routing, acceptance, and cost |
-
-**Prior art & credits.** The "smart brain, cheap hands" split is not pilotfish's invention: Anthropic's own engineering writeup ([Decoupling the brain from the hands](https://www.anthropic.com/engineering/managed-agents)) frames it, Claude Code ships [`opusplan`](https://code.claude.com/docs/en/model-config) built in — if all you want is cheaper sessions, `/model opusplan` needs no repo at all — and [Rylaa/fable5-orchestrator](https://github.com/Rylaa/fable5-orchestrator) packages the same frugality thesis as a plugin with ledger-enforcing guard hooks. pilotfish's contribution is the packaging: eight deliberately-few roles instead of a 100-agent catalog, a role-based policy that survives model churn, an installer that shows its plan before touching anything, and claims that were adversarially fact-checked. If a heavier, hook-enforced flavor fits you better, use theirs.
-
-## Contributing
-
-See [CONTRIBUTING.md](./CONTRIBUTING.md) for the test workflow, source-of-truth
-map, exact-byte evidence rules, and pull request checklist.
-
-## Uninstall
-
-Tell Claude Code:
+To delegate uninstall to Claude Code:
 
 ```text
 Read the local install/AGENT-INSTALL.md, resolve the Claude Code configuration
@@ -317,22 +167,23 @@ Show me the full removal and settings-restoration plan and get my approval
 before writing.
 ```
 
-## Support pilotfish
+## Documentation
 
-pilotfish is only configuration, but proving that its policy still works is not
-free. Meaningful compatibility claims require paid Claude Code or API runs
-across multiple model tiers, multi-turn dispatch Gates, and fresh independent
-verifier sessions. Runs that hit quota limits or expose a policy flaw are
-disclosed and, when feasible, rerun rather than counted as proof.
+| Topic | Document |
+|---|---|
+| Daily use and troubleshooting | [docs/usage.md](./docs/usage.md) · [繁體中文](./docs/usage.zh-TW.md) |
+| Architecture and policy decisions | [docs/design.md](./docs/design.md) |
+| Model economics and source research | [docs/research.md](./docs/research.md) · [繁體中文](./docs/research.zh-TW.md) |
+| Real long-session field report | [docs/field-report-tokscale-2026-07.zh-TW.md](./docs/field-report-tokscale-2026-07.zh-TW.md) |
+| Behavioral evidence and claim limits | [dispatch brake](./benchmarks/dispatch-brake/README.md) · [spontaneous dispatch](./benchmarks/spontaneous-dispatch/README.md) · [Baton activation](./benchmarks/baton-dispatch-effect/README.md) · [prompt compression](./benchmarks/prompt-compression/README.md) · [verifier boundary](./benchmarks/verifier-boundary/README.md) |
+| Contribution and evidence contracts | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 
-Sponsorship helps cover those model credits and the ongoing work of tracking
-Claude Code changes, provider aliases, role templates, installer behavior, and
-[release evidence](./benchmarks/baton-dispatch-effect/README.md). If pilotfish
-saves you quota or review time, you can support its continued development on
-Patreon.
+## Project
+
+pilotfish is MIT licensed. Behavioral compatibility claims require paid model
+runs, fresh verification, and maintained evidence; sponsorship helps fund those
+gates.
 
 [![Support pilotfish on Patreon](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 
-## License
-
-[MIT](./LICENSE)
+[License](./LICENSE) · [Contributing](./CONTRIBUTING.md)

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -127,7 +127,7 @@ full plan of changes and get my approval before writing anything.
 
 | 目標 | 安裝內容 | 可還原 |
 |---|---|---|
-| `settings.json` | 補上缺少的 `model` 與 `fallbackModel`；除非批准，否則保留既有選擇 | 可 |
+| `settings.json` | 補上缺少的 `model` 與 `fallbackModel`；既有 `availableModels` 白名單才會補必要 alias | 還原或移除 `model`；可移除 `fallbackModel`，白名單 additions 除非要求否則保留 |
 | `agents/` | 八個角色 agent 檔 | 可 |
 | `CLAUDE.md` | 一段有版本的 `pilotfish:begin/end` policy block | 可 |
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -1,308 +1,150 @@
 # pilotfish 🐟
 
-> 領航魚與海中最大的掠食者同游——小而快，把例行工作攬下來，讓大傢伙專心做只有牠能做的事。
+> 小而快的角色 agents 處理大量工作；前沿主 session 保留規劃、批准、整合與最終判斷。
 
-**pilotfish** 是 [Claude Code](https://code.claude.com) 的多模型協作層：`opus` family 在主 session 負責規劃與決策，Sonnet 與 Haiku 透過全域 subagent 承接大量執行工作，再由 fresh Opus context 挑戰 Plan 與完成結果。品質靠獨立驗證把關，而不是靠處處使用最大的模型。所有設定安裝在全域層——設定一次、所有專案生效——而且整套架構在主模型不可用時能無感降級。
+**pilotfish** 是 [Claude Code](https://code.claude.com) 的全域多模型編排政策。
+新安裝以 `opus` family 作為主 session，Sonnet 與 Haiku 負責有界的執行與偵察，
+風險觸發的 review 則使用全新 Opus context。它安裝的是設定，不是 runtime service，
+也不會寫入你的專案。
 
-> **想在 Claude Code 裡使用 OpenAI GPT-5.6，又不改動原生 Claude state？** [remora](https://github.com/Nanako0129/remora-cc) 把 pilotfish 的角色分工模式包裝成 session-scoped launcher，連接既有的 Anthropic-compatible gateway。想研究或客製全域 orchestration policy，可以使用 pilotfish；想要經過批准、可驗證，而且 model 與 gateway override 會隨 child process 消失的安裝方式，可以使用 remora。
-
-> **想在 Grok Build 上跑同一套編排？** [pilotfish-grok](https://github.com/Nanako0129/pilotfish-grok) 把角色 lifecycle 與能力邊界移植到 `~/.grok/`（agents、roles、無模型名政策）。Claude Code 用本 repo；宿主是 Grok Build 時用 pilotfish-grok——安裝面獨立，不寫入 `~/.claude/`。
-
-**這個專案的由來：** 某天早上我的週額度重置了，拿到新一週的 Fable 5 額度後做的第一件事，是要它研究上一週的額度為什麼蒸發。這個 repo 就是那次研究的落地成果，也是我現在每個專案每天都在跑的設定——三個設定檔，沒有任何 runtime 程式碼。附出處的研究筆記在 [docs/](./docs/)。
-
-[English README](./README.md)
+[English](./README.md)
 
 ## 目錄
 
 - [為什麼](#為什麼)
 - [運作方式](#運作方式)
 - [安裝](#安裝)
-- [信任與安全](#信任與安全)
-- [安裝內容](#安裝內容)
-- [更新](#更新)
-- [Fallback 機制](#fallback-機制)
-- [調校與常見問題](#調校與常見問題)
-- [研究與設計](#研究與設計)
-- [參與貢獻](#參與貢獻)
-- [移除](#移除)
-- [支持 pilotfish](#支持-pilotfish)
-- [授權](#授權)
+- [日常操作](#日常操作)
+- [文件](#文件)
+- [專案資訊](#專案資訊)
 
 ## 為什麼
 
-Anthropic 在 2026-07-24 發布 [Opus 5](https://www.anthropic.com/news/claude-opus-5)，官方定位是接近 Fable 5 的智慧、API 價格只有一半。Opus 5 在 Anthropic 公布的多項評測領先，但不是每一項都贏。因此 pilotfish 把**新安裝**預設改成 `opus` family alias，Fable 5 改為明確使用 `/model fable` 才啟用。這是成本導向的預設值，不是宣稱 Opus 5 全面勝過 Fable 5；決策與 rollback 條件記錄在 [#23](https://github.com/Nanako0129/pilotfish/issues/23)。
+Coding session 的大量 tokens 用在搜尋、重複修改、測試與文件，而不是前沿判斷。
+pilotfish 把這些有界工作交給較便宜的角色，main session 仍對結果負責，並在重要
+acceptance boundary 使用 fresh-context reviewer。
 
-原本 7 月的研究仍然解釋了這套架構：前沿模型 session 昂貴，但 coding session 裡大多數 token 是搜尋、機械性編輯、跑測試與更新文件，而不是判斷。這些高量工作可以交給 Sonnet 或 Haiku，接受邊界再用 fresh Opus context 審查。
+新安裝預設使用 `opus` alias；Fable 仍可用 `/model fable` 明確選擇。這是成本導向的
+預設，不代表某個模型在所有任務都更好。理由與數據請見 [研究報告](./docs/research.zh-TW.md)、
+[設計說明](./docs/design.md) 與 [#23](https://github.com/Nanako0129/pilotfish/issues/23)。
 
-這套做法的每一塊現在都有 Anthropic 背書。[Fable 5 prompting 指南](https://platform.claude.com/docs/en/build-with-claude/prompt-engineering/prompting-claude-fable-5)建議頻繁委派 subagent，並指出「**獨立的 fresh-context 驗證者 subagent 效果優於模型自我批判**」；而 2026-07-08 起，「便宜模型執行」也有了官方 benchmark：Anthropic 自家測試中 **Fable 5 orchestrator + Sonnet 5 workers 達到全 Fable 效能的 96%、成本只要 46%**（BrowseComp：準確率 86.8% vs 90.8%、每題 $18.53 vs $40.56），反向的 advisor 模式（Sonnet 執行、諮詢 Fable）則是約 92% 效能、63% 成本（SWE-bench Pro）——pilotfish 採用的 orchestrator 分工在兩個軸上都勝出（[multi-agent 文件](https://platform.claude.com/docs/en/managed-agents/multi-agent)）。社群實驗在業餘規模指向同一方向——高度委派的 12-worker 稽核（[Developers Digest](https://www.developersdigest.tech/blog/fable-5-orchestrator-model-playbook)），偏最佳情境、API 美元計價：
-
-| 配置（12-worker 稽核實驗，Developers Digest） | 成本 | 節省 |
-|---|---|---|
-| 全程 Fable 5 | $14.50 | — |
-| Fable 5 協調 + Sonnet workers | $6.10 | 58% |
-| Fable 5 協調 + Haiku workers | $3.70 | 74% |
-
-訂閱制用戶還能疊加兩個額外紅利：
-
-> **提示：** Claude 訂閱採雙桶每週限額（[官方文章](https://support.claude.com/en/articles/14552983-models-usage-and-limits-in-claude-code)）——共用的「所有模型」桶之外，另有一個 **Sonnet 專用的額外桶**。把執行工作路由給 Sonnet subagent 不只單價便宜，還能動用這份額外的專屬額度。（Sonnet 用量仍會計入「所有模型」桶——這是額外配額，不是完全獨立的池子。）
-
-> ⚠️ **警告：** Claude Code v2.1.198 起，內建的 `Explore` subagent 會繼承主 session 的模型。如果你的主 session 跑 Fable 5 或 Opus，每一次背景搜尋都在燒 Opus 級的 token（Claude API 上 Explore 繼承的模型以 Opus 封頂；第三方平台無此上限）。pilotfish 會把它覆寫回 Haiku。（坦白揭露一個代價：自訂的 Explore 會像一般 subagent 一樣載入你的使用者記憶，而內建版會跳過——政策區塊對 subagent 角色會自我停用，把這個開銷壓到最小。）
-
-> **注意：** 上面兩點是訂閱方案的機制。在按 token 計費的 API 上，單價層面的節省依然成立（但沒有週額度桶）。Model alias 仍受 provider、帳號與 settings 影響：已記錄的乾淨 first-party Gate 把 `opus` 解析成 Opus 5，同一版 client 載入 user setting source 時則解析成 Opus 4.8。若需要精確 deployment，請使用完整 model ID 或平台的 `ANTHROPIC_DEFAULT_*_MODEL` 環境變數。
+| Host 或用途 | 專案 |
+|---|---|
+| Claude Code 全域政策 | 本 repo |
+| Claude Code 的 session-scoped GPT routing | [remora](https://github.com/Nanako0129/remora-cc) |
+| Grok Build | [pilotfish-grok](https://github.com/Nanako0129/pilotfish-grok) |
+| Codex CLI | [pilotfish-codex](https://github.com/miyago9267/pilotfish-codex) |
 
 ## 運作方式
 
-三層架構、三處設定，全部在 `~/.claude/` 底下：
-
-> **設定根目錄**：以下路徑是預設值。若你設了 [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars)，下列每個 `~/.claude/` 路徑都改在該目錄底下；[安裝 runbook](./install/AGENT-INSTALL.md) 會在 Step 0 解析它。
-
-> ⚠️ **安裝成功不保證會自動委派。需要 lifecycle 時請加上明確 opt-in。**
-> Claude Code 較高優先級的指示可能壓制 Agent 委派，而使用者層的 `CLAUDE.md`
-> 無法覆蓋它們。這不限於單一訂閱方案。在一個使用 Claude Code 2.1.220 的
-> first-party Pro 帳號上，兩次 cue-free schema attempt 都沒有委派；同一台機器、
-> 同一個 client 升級 Max 之後，一組四格 baseline **四次正向嘗試只有一次**達到預期
-> 拓撲——十二檔案的 mechanical 那格兩次全失敗，主 session 自己改完全部檔案。
-> Max 上觀察到委派、Pro 上沒有，但這兩者不構成排序：測試格不同、repository 樹
-> 隨方案一起變動，而且區區數次嘗試不是發生率。有兩個各自獨立、gate 不同的注入：
-> 訂閱層級那個在 Max 上實測消失，session guidance 那個仍在。**兩種方案都不可靠。**
-> 需要 orchestration lifecycle 時，請在 request 加上
-> `Use pilotfish. Follow its dispatch brake: keep direct work in the main session and call the named agents only when the policy selects delegation.`。
-> 歷史 Pro 明確臂曾啟動 `scout`、`plan-verifier`、`mech-executor` 與 `verifier`。
-> 目前 Max recovery matrix 則啟動 `plan-verifier`、`mech-executor` 與 `verifier`，
-> 同時讓 routine docs 與單一未知 bug 保持 direct；其他 roles 未在這組 matrix 測試。
-> 目前不把此觀察歸因於 prompt compression：未修改的 v1.3.3 cue-free control
-> 與 v1.3.4 壓縮版同樣是 0 dispatch。逐格證據，以及那些記錄裡「cue-free」
-> 究竟指什麼、不指什麼，見
-> [`benchmarks/spontaneous-dispatch`](./benchmarks/spontaneous-dispatch/README.zh-TW.md)。
-> 後續的 Calico 2.1.223 TUI 嘗試也維持 direct。四個可讀的 thinking block
-> 顯示模型自己陳述的決策依據；有邊界的證據與主張限制記錄在
-> [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json)。
-> 追蹤：[#29](https://github.com/Nanako0129/pilotfish/issues/29)。
-
-<details>
-<summary><b>機制是什麼</b>——兩個各自獨立的注入，以及哪些能主張、哪些不能</summary>
-
-先前被當成同一件事討論的，其實是兩個不同的注入。兩者都是從 `~/.local/share/claude/versions/` 底下的官方 Claude Code build 讀出來的；以下每一項主張都錨定在你可以自己搜尋的字串，而不是 byte offset。
-
-| | 本 repo 追蹤的那個 | 另一個 |
+| 層級 | 安裝位置 | 責任 |
 |---|---|---|
-| 位置 | Agent tool description | system prompt 區段，flag 名稱 `tengu_heron_brook` |
-| 文字 | `Do not spawn agents unless the user asks.` … `it's the expensive path on this plan.` | `Do not call the AgentTool unless the user requested it` |
-| gate | 在 tool-description builder 內就地比對訂閱方案是否為 `"pro"`，該運算式本身沒有任何 override | resolver `dMy`，三個依序來源——見下 |
-| 追蹤於 | [#29](https://github.com/Nanako0129/pilotfish/issues/29) | [Serhii-Leniv/claude-router#55](https://github.com/Serhii-Leniv/claude-router/issues/55)、[anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988) |
+| Machine | `~/.claude/settings.json` | 主模型 alias 與 fallback chain |
+| Roles | `~/.claude/agents/*.md` | 每個角色的模型、effort 與 capability boundary |
+| Policy | `~/.claude/CLAUDE.md` | Dispatch、approval、verification 與長跑行為 |
 
-第二個是**字串值**的區段，不是布林值。在 2.1.220 中，`dMy` 依序從 client data、flag 查詢、內建預設值解析內容；前兩個來源可以塞任意文字。`opus_5_prompt_bundle` capability 檢查與它的 killswitch 位在 `tXn`，而 `tXn` **只**管內建預設值那一支。
-
-在我們留存的官方 build 上做三次獨立的字串搜尋：
-
-| 官方 build | tool-description 段落 | `tengu_heron_brook` 識別字 | 內建預設 payload |
-|---|---|---|---|
-| 2.1.218 | present | present（7 次） | absent |
-| 2.1.219 | present | present | present |
-| 2.1.220 | present | present | present |
-
-**主張邊界。** 字串存在於 binary 不等於該指令在 session 中生效；三個 build 也無法證明上游何時引入某項東西——那一側的來源是 [anthropics/claude-code#80988](https://github.com/anthropics/claude-code/issues/80988)。我們沒有找到任何有文件的使用者層設定可以持久 opt-in，但也不主張這種設定不存在；那需要我們尚未蒐集的 CLI 與 settings 證據。以下僅作為佐證，來自我們自己重新封裝的 Claude Code 原生 build [Calico](https://github.com/Nanako0129/calico-claude)：tool-description 段落存在於 2.1.207 與 2.1.220 之間所有十個留存的 build——那是一組不連續的版本，不是該區間的每一個 release。
-
-**這是診斷，不是證明。** 開一個新 session 詢問其委派政策，可以取得模型對限制的自述。後續的 Calico 2.1.223 TUI 診斷保存了四個可讀的 thinking block，並顯示模型把較高優先級的指令視為禁止使用 AgentTool。這是行為證據，不是實際生效的 system-prompt 原始 bytes；見 [`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json)。
-
-**如果你同時使用 [claude-router](https://github.com/Serhii-Leniv/claude-router)：** 裝了 pilotfish 就不要開 `forceRoute`。它會覆蓋每個 agent 在自己 frontmatter 設定的模型，而那正是 pilotfish 讓 `verifier` 拿到全新 Opus context 的方式；已有實測觀察到一個釘在 Opus 的角色跑在 `claude-sonnet-5` 上。該工具的 `restoreDelegation` 選項則會剝除上面第二個注入。
-
-</details>
-
-| 層 | 檔案 | 職責 |
-|---|---|---|
-| 機器層 | `~/.claude/settings.json` | 決定誰當 orchestrator（`opus`）＋自動 `fallbackModel` 切換鏈 |
-| 角色層 | `~/.claude/agents/*.md` | 八個角色 agent，以 frontmatter 綁定正確模型層級與 capability surface |
-| 政策層 | `~/.claude/CLAUDE.md` | 規範「怎麼委派」——只寫角色，永不寫模型名 |
+如果設定了 `CLAUDE_CONFIG_DIR`，以上所有 `~/.claude/` 路徑都移到該設定根目錄。
 
 ```mermaid
 flowchart TD
-    U[你] --> O
+    U["你"] --> O
     subgraph MAIN["主 session — opus family alias"]
-        O["Orchestrator<br>規劃 / 決策 / 撰寫規格 / 審查"]
+        O["Orchestrator
+規劃 / 決策 / 撰寫規格 / 審查"]
     end
-    O -->|偵察搜尋| S["scout / Explore<br>haiku · effort low"]
-    O -->|挑戰 Plan| PV["plan-verifier<br>opus · 唯讀"]
+    O -->|偵察搜尋| S["scout / Explore
+haiku · effort low"]
+    O -->|挑戰 Plan| PV["plan-verifier
+opus · 唯讀"]
     PV -->|READY / REVISE| O
-    O -->|機械性規格| M["mech-executor<br>sonnet · effort low"]
-    O -->|需判斷的實作| E["executor<br>sonnet · effort medium"]
-    O -->|資安證據| SR["security-reviewer<br>opus · 唯讀"]
+    O -->|機械性規格| M["mech-executor
+sonnet · effort low"]
+    O -->|需判斷的實作| E["executor
+sonnet · effort medium"]
+    O -->|資安證據| SR["security-reviewer
+opus · 唯讀"]
     SR --> O
-    O -->|已批准資安實作| SEC["security-executor<br>opus · effort high"]
-    M --> V["verifier<br>opus · fresh context"]
+    O -->|已批准資安實作| SEC["security-executor
+opus · effort high"]
+    M --> V["verifier
+opus · fresh context"]
     E --> V
     SEC --> V
     V -->|CONFIRMED / REFUTED / INCONCLUSIVE| O
 ```
 
-八個角色：
-
 | 角色 | 模型 | Effort | 用途 |
 |---|---|---|---|
-| `scout` | haiku | low | 唯讀查找：「X 在哪／怎麼運作」、symbol 用法、設定值 |
-| `Explore` | haiku | low | 覆寫內建 Explore agent（見上方警告） |
-| `plan-verifier` | opus | medium | 唯讀審查一個 Plan envelope 或 slice；回覆單獨 `READY` 或結構化 `REVISE` |
-| `security-reviewer` | opus | high | 批准前以 tool 強制唯讀收集資安證據與 threat review |
-| `mech-executor` | sonnet | low | 規格完整的機械性工作：pattern 重構、照慣例寫測試、文件、批次編輯 |
-| `executor` | sonnet | medium | 需要判斷的實作：功能開發、bug 修復、涉及設計的重構 |
-| `verifier` | opus | medium | Fresh-context calibrated outcome verification；回覆 CONFIRMED/REFUTED/INCONCLUSIVE，永不動手修 |
-| `security-executor` | opus | high | 已批准的資安實作——刻意不走 Fable 5，其安全分類器可能誤拒良性的防禦性資安工作 |
+| `scout` | haiku | low | 唯讀 repo 偵察 |
+| `Explore` | haiku | low | 不繼承主模型的廣域唯讀搜尋 |
+| `plan-verifier` | opus | medium | 批准前挑戰 Plan：`READY` 或結構化 `REVISE` |
+| `security-reviewer` | opus | high | 批准前蒐集唯讀資安證據 |
+| `mech-executor` | sonnet | low | 規格完整的機械性重複工作 |
+| `executor` | sonnet | medium | 已批准且需要局部判斷的實作 |
+| `verifier` | opus | medium | 實作後以 fresh context 反駁 outcome claim |
+| `security-executor` | opus | high | 已批准的資安敏感實作 |
 
-`executor` 從 Opus 改成 Sonnet（[#18](https://github.com/Nanako0129/pilotfish/issues/18)），讓預設的委派實作路徑維持在 Opus 主 session 之下。這是針對預設實作路徑的修正，不是要求所有角色都必須跟 main session 不同 tier。四個 Opus 角色維持不變：`verifier` 與 `plan-verifier` 在接受結果前提供 fresh-context challenge；`security-reviewer` 與 `security-executor` 則以正確性優先。同 tier 委派沒有 tier 節省，但仍可能提供獨立 context、能力邊界或平行處理。依 main-session model 自動切換 tier map 的安裝程式方案有被考慮過，但被否決——見 [Deliberately left out](./docs/design.md#deliberately-left-out)。
+小而穩定的工作留在主 session。較大的工作只有在角色拿到穩定、有界 contract，且委派
+整體效益為正時才切分。Independent review 由風險觸發，不以檔案數量判定。精確 lifecycle
+以 [政策範本](./templates/claude-md.orchestration.md) 為準，理由見 [設計說明](./docs/design.md)。
 
-政策層依階段套用不同的 dispatch brake。小而穩定的工作直接完成；大型工作把共享限制放在 program envelope，只拆真正獨立的 execution slice。只有具體的安全、不可逆／外部、資料、release 或跨元件 acceptance 風險才觸發獨立 review，不會只因檔案多或被稱為「non-trivial」就啟動。兩次自動 `REVISE` 後，main session 停止自動重送，將 blocker 分成 `FIX`、`DEFER` 或 `REJECT`，並繼續可獨立批准的 slice。若有修正、縮窄／拆分或改變 readiness claim 的 evidence-backed disposition，建立新的 readiness epoch 並只做一次 final fresh check；再次 `REVISE` 就暫停或升級，不會重開迴圈。只有未解決的高影響或產品／授權決策才交給使用者。
+> ⚠️ **不保證自動委派。** Claude Code 較高優先級的指示可能壓制 Agent dispatch，
+> user-level `CLAUDE.md` 無法覆蓋它。需要 lifecycle 時，請在 request 加上以下文字。
 
-| 階段 | pilotfish 行為 |
-|---|---|
-| Discovery | `scout`／`Explore` 在穩定的 research contract 下收集有界事實；此時實作結果可以仍未知 |
-| Plan | Main session 擁有 envelope 與 slices；風險觸發的 `plan-verifier` review 一次審一個 stable unit，回覆單獨 `READY` 或結構化 `REVISE` |
-| Approval | 大型、架構性、高風險或明確要求 plan-first 的工作，在 source write 或 implementation brief 開始前等待明確批准 |
-| Execution | `mech-executor`、`executor` 或 `security-executor` 接收一份穩定且 ownership 獨佔的 contract |
-| Verification | 對風險觸發的工作，`verifier` 透過 read-and-run tools 獨立測試已完成工作的精確 claim；最終判斷仍由 main session 負責 |
+```text
+Use pilotfish. Follow its dispatch brake: keep direct work in the main session
+and call the named agents only when the policy selects delegation.
+```
 
-若工作可能長時間自主執行，main session 會先針對目前任務宣告 `AUTO` 或 `ASK`；`/goal` 只保留目標，不授予權限。`AUTO` 只涵蓋已批准 scope 內的可逆工作；`ASK` 透過原生輸入或 `PAUSED_NEEDS_USER` 暫停。P0 會凍結受影響的 slice；P1 必須修正或暫停。正常 verification 是一輪完整檢查，修正可重現 blocker 後再做一次定向複驗；五輪只保留為高風險 P1/P2 recovery 的緊急上限。
-
-具備完整 one-shot brief、獨佔 ownership 與逐項驗收的穩定多檔機械性重複工作，預設在主 session 編輯前交給唯一一個 `mech-executor`；只有在編輯前點名具體 blocker 才能推翻此預設，逐項 triage、例外、整合與驗收仍由主 session 擁有。
-
-長時間 process 仍由 main session 擁有。所有可用 Bash 的 leaf role（`mech-executor`、`executor`、`verifier`、`security-executor`）只以前景方式執行有界 command，不會用 `nohup`、`setsid`、尾端 `&` 或 subagent-side background execution 來 detach；若工作無法在 10 分鐘內完成，就把精確 command、絕對 worktree／working directory、必要 environment 與 input paths 交回 orchestrator。Orchestrator 必須在同一個 context 執行，不能默認改到 parent checkout。任何可能執行長 command 的 agent，本身必須用 `run_in_background: true` spawn，才能保留 harness tracking 與 completion notification。
+有邊界的結果與主張限制記錄在
+[spontaneous-dispatch benchmark](./benchmarks/spontaneous-dispatch/README.zh-TW.md) 與
+[`cue-free-tui.json`](./benchmarks/spontaneous-dispatch/cue-free-tui.json)。這些是行為觀察，
+不是 dispatch rate，也不是 active system-prompt bytes 的證明。
 
 ## 安裝
 
-建議的路徑是先把釘選的 v1.3.8 release clone 到本機，再從該 checkout 啟動 Claude Code，讓它讀取本地 runbook：
+Clone 已審閱的 release，從該 checkout 啟動 Claude Code，再要求它讀取本地 runbook：
 
-```sh
+```bash
 git clone --branch v1.3.8 --depth 1 https://github.com/Nanako0129/pilotfish.git
 cd pilotfish
 claude
 ```
 
-在這個 Claude Code session 貼上：
-
 ```text
-Read the local file install/AGENT-INSTALL.md in the current checkout and follow it to install pilotfish into my global Claude Code configuration.
-Show me the full plan of changes and get my approval before writing anything.
+Read the local file install/AGENT-INSTALL.md in the current checkout and follow
+it to install pilotfish into my global Claude Code configuration. Show me the
+full plan of changes and get my approval before writing anything.
 ```
 
-Claude 會讀取本地安裝 runbook、檢查你既有的設定、先給你一份合併計畫（不會盲目覆寫任何東西），經你同意後才動手。安裝是冪等的——重跑一次等於原地升級。
+> **Runtime 要求：** Claude Code **2.1.219 或更新版本**。安裝後請重啟 Claude Code，
+> 讓 agents 目錄與 model 設定重新載入。
 
-> **Runtime 要求：** Claude Code **2.1.219 或更新版本**。這是 pilotfish 對 Opus 5-aware alias routing 的已測試最低版本，也比已驗證的 agent `tools` 強制執行基準更新；它不保證每個 provider、帳號或 settings stack 都解析到同一個 backend。若版本更舊或無法辨識，安裝程式會在變更任何檔案前停止。原生 Windows（無 WSL）下 runbook 的 shell 指令假設 POSIX 環境，安裝代理已被指示改用自身檔案工具處理。安裝後請重啟 session：agents 目錄在 session 啟動時掃描，`model` 設定在重啟後生效。
+> ⚠️ **信任邊界：** policy 會載入未來每個 session。批准寫入前，請檢查釘選的 checkout、
+> [agent templates](./templates/agents/)、[policy template](./templates/claude-md.orchestration.md)
+> 與 [安裝 runbook](./install/AGENT-INSTALL.md)。不要為了從可變動的 raw URL 安裝而繞過
+> WebFetch prompt-injection 防護。
 
-為方便起見，也可以貼上下面的 GitHub raw prompt。這是可變動、未釘選的便利路徑：它跟著 `main` 走，因此從審閱到安裝之間，runbook 與範本可能各自變動；此外，Claude Code 的 WebFetch prompt-injection 防護可能會攔截一份直接對 AI 下達安裝指示的遠端文件。若被攔截，請改用上面的本地 checkout 路徑；不要停用或繞過安全檢查。
-
-```text
-Read https://raw.githubusercontent.com/Nanako0129/pilotfish/main/install/AGENT-INSTALL.md
-and follow it to install pilotfish into my global Claude Code configuration.
-Show me the full plan of changes and get my approval before writing anything.
-```
-
-想手動安裝？同樣的步驟寫在 [install/AGENT-INSTALL.md](./install/AGENT-INSTALL.md)，所有安裝檔的原始範本都在 [templates/](./templates/)。
-
-## 信任與安全
-
-pilotfish 的安裝方式，是讓 Claude 從本 repo 讀取 runbook 與範本檔、合併進你的全域 `~/.claude/` 設定——其中包含一段會載入**未來每一個 session** 的政策區塊。請把它當成任何 `curl | sh` 看待：信任來自這個 repo 與你的 GitHub 連線，而不是那段貼上的文字。建議使用本地 checkout，因為你可以先檢查釘選的 release，再讓 Claude 讀取 runbook。執行前：
-
-- **實際會被裝進去的檔案要親自讀過**，不只是 runbook：就是 [templates/agents/](./templates/agents/) 的八個檔案加上 [templates/claude-md.orchestration.md](./templates/claude-md.orchestration.md)。除此之外不會寫入任何東西。
-- **釘選到 release tag 或 commit**，確保你審過的就是實際裝的——從你讀它、到 Claude 讀它之間，`main` 是可能變動的。上面的建議指令已釘選 `v1.3.8` release tag；要最嚴格保證時，請先 fetch 並 checkout 你審閱過的完整 commit SHA，再在啟動 Claude 前驗證 checkout。
-- **保留 approval gate：** 經你同意前 Claude 不會動手，但計畫仍只是 runbook 的摘要。請自行審閱本地 runbook 與範本；若 raw URL 被攔截，也不要削弱或繞過 WebFetch 的 prompt-injection 防護。
-
-## 安裝內容
-
-> **設定根目錄**：以下路徑是預設值。若你設了 [`CLAUDE_CONFIG_DIR`](https://code.claude.com/docs/en/env-vars)，下列每個 `~/.claude/` 路徑都改在該目錄底下；[安裝 runbook](./install/AGENT-INSTALL.md) 會在 Step 0 解析它。
-
-| 目標 | 變更 | 可還原 |
+| 目標 | 安裝內容 | 可還原 |
 |---|---|---|
-| `~/.claude/settings.json` | Key 缺少時設定 `model` → `"opus"`、`fallbackModel` → `["sonnet"]`；既有選擇除非經你批准否則保留；若 `availableModels` 原本就有限制，確保 `opus`、`fable`、`sonnet`、`haiku` 仍可選 | 可——各 key 彼此獨立 |
-| `~/.claude/agents/` | 八個角色 agent 檔（如上表） | 可——刪檔即可 |
-| `~/.claude/CLAUDE.md` | 一段 `## Orchestration`，包在 `<!-- pilotfish:begin/end -->` 標記之間 | 可——移除標記區塊 |
+| `settings.json` | 補上缺少的 `model` 與 `fallbackModel`；除非批准，否則保留既有選擇 | 可 |
+| `agents/` | 八個角色 agent 檔 | 可 |
+| `CLAUDE.md` | 一段有版本的 `pilotfish:begin/end` policy block | 可 |
 
-不會寫入任何專案目錄。這是刻意的設計——理由見設計文件。
+Installer 可重複執行，寫入前會先顯示 merge plan。人類可讀的步驟、backup、名稱衝突、
+verification、更新與移除都在 [install/AGENT-INSTALL.md](./install/AGENT-INSTALL.md)。
 
-## 更新
+## 日常操作
 
-安裝程式是冪等的，所以**把安裝 prompt 再貼一次就是更新**——沒變的檔案自動跳過、政策區塊原地替換、settings 只在缺 key 時才動。要釘選版本更新時，先取得想升級到的 release tag，把該 tag 的 checkout clone 到本機，再從裡面啟動 Claude Code：
-
-```sh
-git clone --branch <RELEASE_TAG> --depth 1 https://github.com/Nanako0129/pilotfish.git
-cd pilotfish
-claude
-```
-
-如果需要改用完整 commit SHA，請先 fetch 並 checkout 該 SHA，再啟動 Claude Code。
-
-接著貼上：
-
-```text
-Read the local file install/AGENT-INSTALL.md in the current checkout and follow its "Updating an existing install" section: detect my installed pilotfish version, show me the changelog since then, and upgrade after my approval.
-```
-
-[安裝](#安裝)裡的 raw `main` prompt 仍是可變動的便利路徑，不是釘選或可靠的更新路徑；它可能被 WebFetch 的 prompt-injection 防護攔截，也不可以拿來繞過這道防護。
-
-| 想要…… | 做法 |
+| 任務 | 文件或方法 |
 |---|---|
-| 查目前安裝的版本 | `CFG="${CLAUDE_CONFIG_DIR:-$HOME/.claude}"; grep -o "pilotfish v[0-9.]*" "$CFG/CLAUDE.md"`——有標記但查不到版本＝v1.1.0 之前的安裝，建議更新 |
-| 收到新版通知 | 在 GitHub 對本 repo 按 **Watch → Custom → Releases** |
-| 看改了什麼 | [CHANGELOG.md](./CHANGELOG.md)——每個版本都有對應的 git tag |
-| 凍結在審核過的版本 | 用 tag 或 SHA 釘選安裝（見[信任與安全](#信任與安全)）——釘選的安裝在你重新釘選前不會變動 |
+| 調整模型、effort、委派或 managed settings | [使用指南](./docs/usage.zh-TW.md) |
+| 更新既有安裝 | [Runbook：Updating an existing install](./install/AGENT-INSTALL.md#updating-an-existing-install) |
+| 查看版本變更 | [CHANGELOG.md](./CHANGELOG.md) |
+| 只對一個專案停用 | 使用另一個 `CLAUDE_CONFIG_DIR`；詳見 [使用指南](./docs/usage.zh-TW.md#停用更新或移除) |
+| 安全移除 | [Runbook：Uninstall](./install/AGENT-INSTALL.md#uninstall) |
 
-## Fallback 機制
-
-這一節談的是主模型消失時架構還「能不能動」，不是「省不省錢」。新安裝使用 `opus` family alias，平台更換 Opus 版本時不必修改政策；另外用 Sonnet fallback 接住主模型的暫時性失敗。政策文字不指名模型，因此角色 routing 仍獨立留在 agent frontmatter：
-
-| 失效情境 | 誰接住 | 你要做什麼 |
-|---|---|---|
-| 主 Opus 過載／不可用 | `fallbackModel: ["sonnet"]` 自動切換並顯示通知 | 不用做 |
-| 某層模型被棄用（Opus 4.8 → 4.9、Sonnet 5 → 下一代） | 角色 agent 用 alias（`opus`、`sonnet`、`haiku`），自動跟隨官方推薦版本 | 不用做 |
-| 已 opt-in 的 Fable session 在任務中途拒絕資安工作 | 資安工作一開始就路由給 `security-executor`（Opus），不會碰到 Fable 的分類器 | 不用做 |
-| 預設委派實作路徑跟 Opus main loop 疊到同一 tier | `executor` 固定走 Sonnet | 如果環境覆寫了 tier，就改 `executor` 的 `model:` 那一行 |
-
-`CLAUDE.md` 裡的委派政策只提角色（`executor`、`scout`……）。模型綁定只存在一個地方——每個 agent 檔的一行 frontmatter——要改指向，改一行、處處生效。
-
-## 調校與常見問題
-
-| 問題 | 回答 |
-|---|---|
-| 想省更多額度 | 主 session 切 `/model opusplan`——planning turn 用 Opus、main session 自己的 execution turn 用 Sonnet。這是 main-session 的模型切換，跟 subagent routing 不同；每個角色仍使用自己 frontmatter 綁定的 model。把 `executor` 改成 Sonnet（[#18](https://github.com/Nanako0129/pilotfish/issues/18)）可避免 Opus main-loop fallback 又把預設實作角色升回 Opus；四個明確綁定 Opus 的 review 與 security 角色不變。 |
-| 為什麼 `executor` 用 Sonnet，`verifier` 卻留在 Opus？ | `executor` 是預設的大量實作路徑，所以 Sonnet 能在 Opus 主 session 之下保留較低成本的 tier。`verifier`、`plan-verifier`、`security-reviewer`、`security-executor` 因接受邊界或資安責任而維持 Opus。同 tier 的角色呼叫不代表一定沒用：fresh context、tool capability 邊界與獨立 review 仍可能值得。[#18](https://github.com/Nanako0129/pilotfish/issues/18) 只主張預設實作路徑的 routing 差異與 tier 節省；目前沒有針對 executor 做過 Opus 與 Sonnet 的角色專屬實測。 |
-| 能強制所有 subagent 用同一個模型嗎？ | `CLAUDE_CODE_SUBAGENT_MODEL` 會覆蓋*所有* agent 的 frontmatter——所以 pilotfish 不設它。除非要臨時全域覆寫，否則別設。 |
-| 我有設 `availableModels` 白名單 | 那名單必須包含 agents 用到的所有 alias（`opus`、`sonnet`、`haiku`），否則那些 agent 會被靜默跳過、改為繼承主 session 模型。安裝程式會檢查這件事。 |
-| 為什麼便宜角色都設 `effort: low`？ | Effort 是第二大額度槓桿。Fable 5 世代的模型在 low effort 常已達前代 `xhigh` 的水準；偵察與機械性工作不需要深度思考。 |
-| 主 session 用哪個 effort？ | 需要重判斷的 orchestration 先用 `high`；若額度或延遲更重要再往下降。若 opt-in Fable，請依它的模型專屬 prompting 指南調整。 |
-| 如何明確要求 1M context window？ | 純 `opus` alias 跟隨平台預設。若支援的平台上明確需要 1M，把 `model` 設為 `"opus[1m]"`；pilotfish 不會覆蓋既有選擇。 |
-| Orchestrator 自己完全不動手嗎？ | 會動手——馬上要用的閱讀、少量 repo 檔案掃描、決策、根因探索、trace-driven debugging，以及你明確要*它*判斷的事。其他工作只有在成本、context、時間、隔離或驗證的整體效益高於重建與整合成本時才委派。 |
-| 我的專案有自己的 CLAUDE.md，會衝突嗎？ | 專案檔案完全不會被動到：pilotfish 只寫 Claude Code 的設定根目錄（預設為 `~/.claude/`；`CLAUDE_CONFIG_DIR` 可覆寫）。執行時 Claude Code 會疊加專案層與使用者層記憶。Repo-local 指示可以讓 optional execution 保持 inline，但 mandatory risk review 仍會生效。若要只對該 repo 完整停用，請用另一個不含 pilotfish block 的 `CLAUDE_CONFIG_DIR` 啟動。 |
-| 我也裝了 delegation-planning skill | 請把它視為互補的規劃層。[Baton](https://github.com/cablate/baton) 這類 skill 可以塑造 discovery 問題、worker 數量、ownership、順序與 stop condition；pilotfish 提供具名 Claude 角色、模型分流、leaf-agent 邊界、approval gate 與 verifier contract。[相容性 Gates](./benchmarks/baton-compatibility/README.zh-TW.md) 記錄 v1.3.2 的 envelope → current slice → 批准執行 → `CONFIRMED` lifecycle，也包含因 post-verdict 編輯而必須用第三次 invocation 補驗的 Opus 5 rerun；[prompt-neutral 啟用 Gate](./benchmarks/baton-dispatch-effect/README.zh-TW.md) 另行覆蓋 v1.3.1 的四-scout dispatch。這些是有界的 compatibility 與 reachability 觀察，不代表效率或發生率。pilotfish 不會停用使用者 skills。 |
-| 擔心 subagent 品質 | 風險觸發的 `plan-verifier` 與 outcome `verifier` 會提供 fresh evidence，但 verdict 不取代 main-session judgment。`REVISE` 一次回報所有已知 P0-P2 blocker，P3/P4 只作建議。Main session 將每項 finding 分成 `FIX`、`DEFER` 或 `REJECT`；正常 verification 是一輪完整檢查，修正可重現 blocker 後再做一次定向複驗。 |
-| Spawn agent 不是有額外成本嗎？ | 有——每次 spawn 都是全新 context、要重讀它負責的那部分 codebase，彙整也花 main session 的 token。因此有界的 task-local 掃描預設直接完成；若互相獨立的證據能實質降低 Plan 不確定性，discovery 仍可 fan-out，而 execution 要等 contract 穩定後才委派。公開機械式 control 的 execution-only 區段中，委派的 reported cost field 降低 36.01%，代價是 wall time 增加 7.92%；兩個比較 run 都沒有包含必要的 outcome verifier，因此只能證明便宜 route 可到達，不能宣稱完整 lifecycle savings。研究 fixture 只證明兩個 scout 在該小型任務上的 overhead，不代表 plan-first discovery 一律錯誤。 |
-| 怎麼快速關掉？ | 「全部直接動手」只會停用 optional execution delegation；mandatory risk review 仍會生效。**完整停用：** 把[安裝 runbook](./install/AGENT-INSTALL.md) Step 0 解析出的設定根目錄中，`CLAUDE.md` 裡的 `pilotfish:begin/end` 區塊註解掉，再開新 session。若只停某個 repo，請改用不含該區塊的另一個 `CLAUDE_CONFIG_DIR`。Agent 檔可保留但不會被使用。 |
-| 公司管的機器（managed）？ | Managed settings 優先於使用者層設定：managed 的 `model`、`availableModels` 白名單、或同名的 managed agent 都會蓋過 pilotfish 的使用者層安裝。重啟後角色沒生效就找管理員——pilotfish 設計上不會（也不該）繞過管理政策。 |
-
-## 研究與設計
-
-這個 repo 是一輪有出處的研究（官方文件、Anthropic 公告、社群實測）加上設計論證的落地成果。同一套編排思路在其他宿主的 port：[pilotfish-grok](https://github.com/Nanako0129/pilotfish-grok)（Grok Build）、[pilotfish-codex](https://github.com/miyago9267/pilotfish-codex)（Codex CLI）、以及 session-scoped GPT 路由的 [remora](https://github.com/Nanako0129/remora-cc)。
-
-| 文件 | 語言 | 內容 |
-|---|---|---|
-| [docs/research.zh-TW.md](./docs/research.zh-TW.md) | 繁體中文 | 完整研究發現：Fable 5 的強項與何時浪費、訂閱經濟學、Claude Code 官方機制、社群實測數字——附來源 |
-| [docs/research.md](./docs/research.md) | English | 研究報告的英文版（忠實翻譯） |
-| [docs/design.md](./docs/design.md) | English | 為什麼是三層、為什麼政策以角色撰寫、為什麼用 alias 不釘版本、effort 分層、以及刻意不做的事 |
-| [benchmarks/dispatch-brake/README.zh-TW.md](./benchmarks/dispatch-brake/README.zh-TW.md) | 繁體中文 + 數據 | 可重現 negative／positive controls、淘汰 policy、Agent traces、成本與時間證據 |
-| [benchmarks/dispatch-brake/positive-controls/README.zh-TW.md](./benchmarks/dispatch-brake/positive-controls/README.zh-TW.md) | 繁體中文 + 數據 | 機械式委派證據，以及小型唯讀 fan-out 的 task-local overhead 與解讀限制 |
-| [benchmarks/spontaneous-dispatch/README.zh-TW.md](./benchmarks/spontaneous-dispatch/README.zh-TW.md) | 繁體中文 + 數據 | 無委派提示的 Opus baseline、v1.3.1 mechanical／bug 拓撲 Gate、sanitized traces 與 Fable credit-gate 揭露 |
-| [benchmarks/baton-dispatch-effect/README.zh-TW.md](./benchmarks/baton-dispatch-effect/README.zh-TW.md) | 繁體中文 + 數據 | Prompt-neutral 啟用矩陣：小型未啟用觀察，以及四領域 Baton 啟用、四個完成 scouts、exclusive ownership、完整 collection 與 output-shape correctness Gate |
-| [benchmarks/baton-compatibility/README.zh-TW.md](./benchmarks/baton-compatibility/README.zh-TW.md) | 繁體中文 + 數據 | Historical exact-byte 原生 Claude 雙 turn lifecycle，加上 Opus 5 rerun 與 corrective 第三次 invocation、精確 prompts、被拒絕的 routing 證據與機器可讀結果 |
-| [benchmarks/prompt-compression/README.zh-TW.md](./benchmarks/prompt-compression/README.zh-TW.md) | 繁體中文 + 數據 | v1.3.4 prompt byte 降幅、runtime context census、candidate 精確 hashes、付費行為觀察與目前主張邊界 |
-| [benchmarks/verifier-boundary/README.zh-TW.md](./benchmarks/verifier-boundary/README.zh-TW.md) | 繁體中文 + 數據 | v1.3.7 exact-byte 原生 Claude schema lifecycle 與 routine-docs control，包含失敗嘗試、role routing、acceptance 與成本 |
-
-**先行者與致意。** 「聰明的腦、便宜的手」這個分工不是 pilotfish 發明的：Anthropic 自己的工程文（[Decoupling the brain from the hands](https://www.anthropic.com/engineering/managed-agents)）就是這個框架，Claude Code 內建 [`opusplan`](https://code.claude.com/docs/en/model-config)——如果你只想要更省的 session，`/model opusplan` 根本不需要裝任何 repo——而 [Rylaa/fable5-orchestrator](https://github.com/Rylaa/fable5-orchestrator) 早就把同樣的節流理念做成帶 ledger 強制 hook 的 plugin。pilotfish 的貢獻在打包方式：刻意只有八個角色而非上百個 agent 的目錄、寫成角色而能撐過模型換代的政策、動手前先出示計畫的安裝流程、以及經過對抗式查核的宣稱。如果你偏好更重、有 hook 強制力的路線，用他們的。
-
-## 參與貢獻
-
-測試流程、source-of-truth 對照、exact-byte 證據規則與 PR checklist
-請見 [CONTRIBUTING.md](./CONTRIBUTING.md)。
-
-## 移除
-
-告訴 Claude Code：
+要把移除交給 Claude Code：
 
 ```text
 Read the local install/AGENT-INSTALL.md, resolve the Claude Code configuration
@@ -312,14 +154,22 @@ Show me the full removal and settings-restoration plan and get my approval
 before writing.
 ```
 
-## 支持 pilotfish
+## 文件
 
-pilotfish 本身只有設定檔，但要證明政策仍能正確運作並不是免費的。具實質意義的相容性宣稱，需要在多個模型等級上執行付費的 Claude Code 或 API 測試、多回合 dispatch Gate，以及全新且獨立的 verifier session。遇到額度限制或暴露政策缺陷的執行，會明確揭露，並在可行時重新執行，而不會直接算成通過證據。
+| 主題 | 文件 |
+|---|---|
+| 日常使用與疑難排解 | [docs/usage.zh-TW.md](./docs/usage.zh-TW.md) · [English](./docs/usage.md) |
+| 架構與政策決策 | [docs/design.md](./docs/design.md) |
+| 模型經濟與來源研究 | [docs/research.zh-TW.md](./docs/research.zh-TW.md) · [English](./docs/research.md) |
+| 真實長 session field report | [docs/field-report-tokscale-2026-07.zh-TW.md](./docs/field-report-tokscale-2026-07.zh-TW.md) |
+| 行為證據與主張限制 | [dispatch brake](./benchmarks/dispatch-brake/README.zh-TW.md) · [spontaneous dispatch](./benchmarks/spontaneous-dispatch/README.zh-TW.md) · [Baton activation](./benchmarks/baton-dispatch-effect/README.zh-TW.md) · [prompt compression](./benchmarks/prompt-compression/README.zh-TW.md) · [verifier boundary](./benchmarks/verifier-boundary/README.zh-TW.md) |
+| 貢獻與證據契約 | [CONTRIBUTING.md](./CONTRIBUTING.md) |
 
-贊助會用於支付這些模型額度，以及持續追蹤 Claude Code 變更、provider alias、role template、installer 行為與[發版證據](./benchmarks/baton-dispatch-effect/README.md)的維護工作。如果 pilotfish 幫你節省了額度或 review 時間，可以透過 Patreon 支持後續開發。
+## 專案資訊
+
+pilotfish 採用 MIT 授權。Behavioral compatibility 主張需要付費模型 runs、fresh verification
+與持續維護的證據；贊助會用於支付這些 Gates。
 
 [![在 Patreon 支持 pilotfish](https://img.shields.io/badge/Support_on_Patreon-FF424D?style=for-the-badge&logo=patreon&logoColor=white)](https://www.patreon.com/cw/Nanako0129/membership)
 
-## 授權
-
-[MIT](./LICENSE)
+[授權](./LICENSE) · [參與貢獻](./CONTRIBUTING.md)

--- a/docs/design.md
+++ b/docs/design.md
@@ -126,6 +126,13 @@ Effort is the second big quota lever after model choice, and the Fable-5 generat
 | An `opusplan` default | It's a great quota-saver but changes interactive feel (model switches mid-conversation). Offered as an opt-in in the FAQ instead. |
 | Installer profiles or main-loop autodetection ([#18](https://github.com/Nanako0129/pilotfish/issues/18)) | The default main session is now explicitly Opus and the default implementation path is Sonnet. A second tier map would double the installer surface without improving that common path; users who opt into another main model can still edit one role alias if needed. |
 
+The "smart brain, cheap hands" split predates pilotfish: Anthropic documents the
+same architecture in [Decoupling the brain from the hands](https://www.anthropic.com/engineering/managed-agents),
+Claude Code already ships [`opusplan`](https://code.claude.com/docs/en/model-config),
+and [Rylaa/fable5-orchestrator](https://github.com/Rylaa/fable5-orchestrator)
+offers a hook-enforced variant. pilotfish's scope is the compact role policy,
+review-before-write installer, and evidence-bounded compatibility claims.
+
 ## Prompting style inside the agents
 
 The agent system prompts follow the current-generation guidance from the research: goals and constraints instead of step-by-step scaffolding, an explicit statement of what *not* to do (no scope creep, verifier never fixes), evidence-audited progress claims, and "a precise *blocked because X* is a successful outcome" to prevent guessing. When editing the templates, keep that register — prescriptive checklists measurably degrade current-generation output.

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -40,6 +40,11 @@ Use pilotfish. Follow its dispatch brake: keep direct work in the main session
 and call the named agents only when the policy selects delegation.
 ```
 
+The optional [activation guide](../install/ACTIVATION-INSTALL.md) offers a
+user-invocable `/pilotfish` skill and a one-line CLI wrapper, with an
+approval-gated AI install contract. Both remain explicit opt-ins, not cue-free
+dispatch; the wrapper can optionally mention an already installed Baton skill.
+
 | Work shape | Expected owner |
 |---|---|
 | Small, local, stable work or one tightly coupled unknown bug | Main session |

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -1,0 +1,104 @@
+# Using pilotfish
+
+This guide collects day-to-day model, delegation, compatibility, and opt-out
+questions. Installation and file mutation rules remain in the
+[install runbook](../install/AGENT-INSTALL.md); exact orchestration behavior
+remains in the [policy template](../templates/claude-md.orchestration.md).
+
+[繁體中文](./usage.zh-TW.md)
+
+## Contents
+
+- [Model routing](#model-routing)
+- [Delegation behavior](#delegation-behavior)
+- [Configuration and compatibility](#configuration-and-compatibility)
+- [Tuning](#tuning)
+- [Long runs and verification](#long-runs-and-verification)
+- [Disable, update, or uninstall](#disable-update-or-uninstall)
+
+## Model routing
+
+| Need | Setting or action | Effect |
+|---|---|---|
+| Default main session | `model: "opus"` | Uses the provider-resolved Opus family alias; the installer preserves an existing choice unless you approve a change |
+| Explicit Fable session | `/model fable` | Opts into Fable without changing role-agent bindings |
+| Lower main-session quota use | `/model opusplan` | Uses Opus for planning turns and Sonnet for the main session's execution turns |
+| Explicit 1M context request | `model: "opus[1m]"` | Requests the documented 1M Opus alias where the provider supports it |
+| Primary model unavailable | `fallbackModel: ["sonnet"]` | Falls back on overload or unavailability; it does not catch authentication, billing, or rate-limit failures |
+
+Each role's model and effort live in its agent frontmatter. Do not set
+`CLAUDE_CODE_SUBAGENT_MODEL` unless you intentionally want to override every
+role, including the Opus review and security roles.
+
+## Delegation behavior
+
+Higher-priority Claude Code instructions can suppress Agent dispatch. When the
+pilotfish lifecycle matters, make the request explicit:
+
+```text
+Use pilotfish. Follow its dispatch brake: keep direct work in the main session
+and call the named agents only when the policy selects delegation.
+```
+
+| Work shape | Expected owner |
+|---|---|
+| Small, local, stable work or one tightly coupled unknown bug | Main session |
+| Stable multi-file mechanical repetition with a complete one-shot brief | `mech-executor` |
+| Approved implementation requiring local judgment | `executor` |
+| Security-sensitive implementation after approval | `security-executor` |
+| Risk-triggered Plan or outcome challenge | `plan-verifier`, `security-reviewer`, or `verifier` |
+
+The [cue-free evidence](../benchmarks/spontaneous-dispatch/README.md) records
+where automatic dispatch did and did not occur. Those observations are bounded
+examples, not a dispatch rate or proof of the active system-prompt bytes.
+
+## Configuration and compatibility
+
+| Situation | What to check |
+|---|---|
+| Custom configuration root | Every `~/.claude/` path moves under `CLAUDE_CONFIG_DIR`; the installer resolves it before writing |
+| Project-level `CLAUDE.md` | Claude Code stacks project and user memory; pilotfish never writes into the project |
+| Custom `Explore` role | Pins reconnaissance to Haiku, but unlike the built-in role it loads user memory; the policy self-disables inside subagent roles to limit that overhead |
+| `availableModels` allowlist | Include `opus`, `fable`, `sonnet`, `haiku`, and the selected main-model value or role aliases may silently inherit the main model |
+| Managed or enterprise settings | Managed models, allowlists, and same-name agents outrank the user-level install; pilotfish does not bypass them |
+| `claude-router` | Keep `forceRoute` off because it overrides agent frontmatter; `restoreDelegation` strips the separately tracked delegation injection |
+| Delegation-planning skills | Tools such as [Baton](https://github.com/cablate/baton) may shape work topology; pilotfish still owns named roles, model routing, approval, and verifier contracts |
+
+## Tuning
+
+| Goal | Adjustment |
+|---|---|
+| Reduce quota use | Use `/model opusplan`; keep reconnaissance and mechanical roles at their shipped low effort |
+| Increase main-session judgment | Start at `high` effort and lower it only when quota or latency matters more |
+| Change one role's tier | Edit only that agent file's `model:` frontmatter; the policy names roles, not models |
+| Keep more work inline | Ask the main session to work inline; this disables optional execution delegation, not mandatory risk review |
+| Understand spawn overhead | Every agent starts a fresh context and pays reconstruction plus integration cost; dispatch only when the combined benefit is positive |
+
+Model economics, official mechanisms, and measured limitations are documented
+in [research](./research.md), the [design rationale](./design.md), and the
+[behavioral benchmarks](../benchmarks/dispatch-brake/README.md).
+
+## Long runs and verification
+
+| State | Meaning |
+|---|---|
+| `AUTO` | Continues reversible work inside approved scope; it grants no new commit, publish, install, destructive, external-action, or spending authority |
+| `ASK` | Pauses for decisions through native input or `PAUSED_NEEDS_USER` |
+| P0 | Freezes the affected slice and its dependants |
+| P1 or introduced P2 | Must be fixed within approved scope or paused; P3/P4 are advisory |
+| `verifier` result | Evidence for main-session judgment, never automatic scope or implementation authority |
+
+Normal verification is one complete pass plus one targeted recheck after a
+reproduced blocker is fixed. Long-running commands stay owned by the main
+session; leaf agents return the exact command and working context instead of
+detaching a process.
+
+## Disable, update, or uninstall
+
+| Action | Method |
+|---|---|
+| Update | Re-run the pinned install prompt and follow the runbook's **Updating an existing install** section |
+| Disable optional execution delegation | Ask the main session to work inline |
+| Disable pilotfish for one repository | Launch that repository with a separate `CLAUDE_CONFIG_DIR` that has no pilotfish policy block |
+| Disable the policy globally | Remove or comment the `pilotfish:begin/end` block, then start a new session |
+| Uninstall | Follow the runbook's **Uninstall** section so agent files and settings backups are handled safely |

--- a/docs/usage.zh-TW.md
+++ b/docs/usage.zh-TW.md
@@ -37,6 +37,10 @@ Use pilotfish. Follow its dispatch brake: keep direct work in the main session
 and call the named agents only when the policy selects delegation.
 ```
 
+選用的[啟用指南](../install/ACTIVATION-INSTALL.md)提供 user-invocable
+`/pilotfish` skill 與一行 CLI wrapper，也包含先取得批准的 AI install contract。
+兩者仍是明確 opt-in，不是 cue-free dispatch；wrapper 可選擇提示已安裝的 Baton skill。
+
 | 工作形狀 | 預期 owner |
 |---|---|
 | 小型、局部、穩定工作，或單一緊密耦合的未知 bug | 主 session |

--- a/docs/usage.zh-TW.md
+++ b/docs/usage.zh-TW.md
@@ -1,0 +1,97 @@
+# 使用 pilotfish
+
+這份文件集中說明日常的模型選擇、委派行為、相容性與停用方式。安裝與檔案變更規則仍以
+[安裝 runbook](../install/AGENT-INSTALL.md) 為準；精確的編排行為仍以
+[政策範本](../templates/claude-md.orchestration.md) 為準。
+
+[English](./usage.md)
+
+## 目錄
+
+- [模型分流](#模型分流)
+- [委派行為](#委派行為)
+- [設定與相容性](#設定與相容性)
+- [調校](#調校)
+- [長時間執行與驗證](#長時間執行與驗證)
+- [停用、更新或移除](#停用更新或移除)
+
+## 模型分流
+
+| 需求 | 設定或操作 | 效果 |
+|---|---|---|
+| 預設主 session | `model: "opus"` | 使用 provider 解析的 Opus family alias；除非你批准，installer 會保留既有選擇 |
+| 明確使用 Fable | `/model fable` | 只切換目前 session，不改各角色 agent 的綁定 |
+| 降低主 session 額度消耗 | `/model opusplan` | 規劃 turn 使用 Opus，主 session 的執行 turn 使用 Sonnet |
+| 明確要求 1M context | `model: "opus[1m]"` | 在 provider 支援時要求官方文件列出的 1M Opus alias |
+| 主模型不可用 | `fallbackModel: ["sonnet"]` | 過載或不可用時 fallback；不處理驗證、計費或 rate-limit 錯誤 |
+
+每個角色的模型與 effort 都在該 agent 的 frontmatter。除非你確實要覆寫所有角色，否則不要設定
+`CLAUDE_CODE_SUBAGENT_MODEL`；它也會覆蓋 Opus review 與 security roles。
+
+## 委派行為
+
+Claude Code 較高優先級的指示可能壓制 Agent dispatch。需要 pilotfish lifecycle 時，請明確寫入：
+
+```text
+Use pilotfish. Follow its dispatch brake: keep direct work in the main session
+and call the named agents only when the policy selects delegation.
+```
+
+| 工作形狀 | 預期 owner |
+|---|---|
+| 小型、局部、穩定工作，或單一緊密耦合的未知 bug | 主 session |
+| 有完整 one-shot brief 的穩定多檔機械性重複工作 | `mech-executor` |
+| 已批准且需要局部判斷的實作 | `executor` |
+| 批准後的資安敏感實作 | `security-executor` |
+| 由風險觸發的 Plan 或 outcome challenge | `plan-verifier`、`security-reviewer` 或 `verifier` |
+
+[Cue-free 證據](../benchmarks/spontaneous-dispatch/README.zh-TW.md) 記錄自動委派在哪些格發生或未發生。
+這些是有邊界的觀察，不是 dispatch rate，也不是 active system-prompt bytes 的證明。
+
+## 設定與相容性
+
+| 情境 | 要檢查什麼 |
+|---|---|
+| 自訂設定根目錄 | 所有 `~/.claude/` 路徑會移到 `CLAUDE_CONFIG_DIR`；installer 會在寫入前解析 |
+| 專案層 `CLAUDE.md` | Claude Code 會疊加專案與使用者記憶；pilotfish 不會寫入專案 |
+| 自訂 `Explore` 角色 | 將偵察固定到 Haiku，但與內建角色不同，它會載入使用者記憶；policy 在 subagent 角色內自我停用，以限制這項開銷 |
+| `availableModels` 白名單 | 納入 `opus`、`fable`、`sonnet`、`haiku` 與選定的主模型，否則角色 alias 可能靜默繼承主模型 |
+| Managed／企業設定 | Managed model、allowlist 與同名 agent 優先於 user-level install；pilotfish 不會繞過它們 |
+| `claude-router` | 不要啟用 `forceRoute`，它會覆寫 agent frontmatter；`restoreDelegation` 會移除另一個被追蹤的 delegation injection |
+| Delegation-planning skill | [Baton](https://github.com/cablate/baton) 等工具可以塑造工作拓撲；具名角色、模型分流、approval 與 verifier contract 仍由 pilotfish 負責 |
+
+## 調校
+
+| 目標 | 調整方式 |
+|---|---|
+| 減少額度消耗 | 使用 `/model opusplan`；偵察與機械性角色維持預設 low effort |
+| 增加主 session 判斷力 | 從 `high` effort 開始，只有在額度或延遲更重要時再降低 |
+| 改單一角色 tier | 只改該 agent 檔的 `model:` frontmatter；政策只寫角色，不寫模型 |
+| 讓更多工作留在主 session | 要求 inline 執行；這只停用 optional execution delegation，不停用 mandatory risk review |
+| 判斷 spawn overhead | 每個 agent 都會建立新 context，需支付重建與整合成本；只有整體效益為正才委派 |
+
+模型經濟、官方機制與實測限制請見 [研究報告](./research.zh-TW.md)、
+[設計理由](./design.md) 與 [行為 benchmark](../benchmarks/dispatch-brake/README.zh-TW.md)。
+
+## 長時間執行與驗證
+
+| 狀態 | 意義 |
+|---|---|
+| `AUTO` | 在已批准 scope 內繼續可逆工作；不新增 commit、publish、install、破壞性、外部操作或付費權限 |
+| `ASK` | 透過原生輸入或 `PAUSED_NEEDS_USER` 暫停等待決策 |
+| P0 | 凍結受影響的 slice 與 dependent work |
+| P1 或 introduced P2 | 在批准 scope 內修正，否則暫停；P3/P4 只作建議 |
+| `verifier` verdict | 供主 session 判斷的證據，不自動授予 scope 或實作權限 |
+
+正常 verification 是一輪完整檢查，加上可重現 blocker 修正後的一次定向複驗。長時間 command
+由主 session 擁有；leaf agent 交回精確 command 與 working context，不自行 detach process。
+
+## 停用、更新或移除
+
+| 操作 | 方法 |
+|---|---|
+| 更新 | 重跑釘選版本的安裝 prompt，並依 runbook 的 **Updating an existing install** 執行 |
+| 停用 optional execution delegation | 要求主 session inline 執行 |
+| 只對一個 repo 停用 | 用不含 pilotfish policy block 的另一個 `CLAUDE_CONFIG_DIR` 啟動該 repo |
+| 全域停用 policy | 移除或註解 `pilotfish:begin/end` block，再開新 session |
+| 移除 | 依 runbook 的 **Uninstall** section 執行，安全處理 agent 檔與 settings backup |

--- a/install/ACTIVATION-INSTALL.md
+++ b/install/ACTIVATION-INSTALL.md
@@ -129,13 +129,13 @@ claude --append-system-prompt "<SESSION_INSTRUCTION>" %*
 ```
 
 Read every installed target back and compare its complete contents with the
-selected payload. Resolve `claude-pilotfish` with `command -v` on POSIX or
-`(Get-Command claude-pilotfish).Source` in PowerShell and compare the result
-with the selected target; stop if they differ. Then run
-`claude-pilotfish --version` to confirm argument forwarding and executable
-state without starting a paid Claude session. Report every backup path. Do not
-modify `settings.json`, the eight role agents, the pilotfish policy block,
-Baton, shell profiles, or `PATH`.
+selected payload. If the CLI wrapper was selected, resolve `claude-pilotfish`
+with `command -v` on POSIX or `(Get-Command claude-pilotfish).Source` in
+PowerShell and compare the result with the selected target; stop if they
+differ, otherwise run `claude-pilotfish --version` to confirm argument
+forwarding and executable state without starting a paid Claude session. Report
+every backup path. Do not modify `settings.json`, the eight role agents, the
+pilotfish policy block, Baton, shell profiles, or `PATH`.
 
 ## Use and verify
 

--- a/install/ACTIVATION-INSTALL.md
+++ b/install/ACTIVATION-INSTALL.md
@@ -51,7 +51,7 @@ Inspect every selected target before writing. Show its existing state, proposed
 content, update behavior, verification, and rollback, then wait for approval.
 Never overwrite an existing target that lacks the matching
 `pilotfish-activation` ownership marker. Stop and ask the user to keep it,
-remove it themselves, or choose another wrapper name or target.
+or remove it themselves.
 
 Before updating a marked Pilotfish-owned target, copy its exact bytes to a new
 timestamped file under `$CFG/backups/pilotfish-activation/history/`, read it

--- a/install/ACTIVATION-INSTALL.md
+++ b/install/ACTIVATION-INSTALL.md
@@ -26,7 +26,10 @@ prompt rather than a user message.
 
 ## Install with AI
 
-Clone a reviewed release, start Claude Code from that checkout, and paste:
+Use a reviewed release checkout that contains this file. If the pinned release
+you installed does not include `install/ACTIVATION-INSTALL.md`, switch to a
+newer reviewed release that does; do not fetch this file alone from `main`.
+Start Claude Code from that checkout and paste:
 
 ```text
 Read the local file install/ACTIVATION-INSTALL.md in the current checkout and
@@ -126,10 +129,13 @@ claude --append-system-prompt "<SESSION_INSTRUCTION>" %*
 ```
 
 Read every installed target back and compare its complete contents with the
-selected payload. Run `claude-pilotfish --version` to confirm wrapper lookup,
-argument forwarding, and executable state without starting a paid Claude
-session. Report every backup path. Do not modify `settings.json`, the eight role
-agents, the pilotfish policy block, Baton, shell profiles, or `PATH`.
+selected payload. Resolve `claude-pilotfish` with `command -v` on POSIX or
+`(Get-Command claude-pilotfish).Source` in PowerShell and compare the result
+with the selected target; stop if they differ. Then run
+`claude-pilotfish --version` to confirm argument forwarding and executable
+state without starting a paid Claude session. Report every backup path. Do not
+modify `settings.json`, the eight role agents, the pilotfish policy block,
+Baton, shell profiles, or `PATH`.
 
 ## Use and verify
 

--- a/install/ACTIVATION-INSTALL.md
+++ b/install/ACTIVATION-INSTALL.md
@@ -1,0 +1,169 @@
+# Install optional pilotfish activation shortcuts
+
+These optional shortcuts remove repeated typing without changing pilotfish's
+role agents or orchestration policy. Install pilotfish with
+[AGENT-INSTALL.md](./AGENT-INSTALL.md) first.
+
+> **Claim boundary:** Both shortcuts are deliberate user opt-ins, not cue-free
+> dispatch. The reference sentence has bounded behavioral evidence. The skill
+> and CLI-wrapper delivery paths have not been separately qualified for
+> dispatch reliability or frequency.
+
+## Choose an activation path
+
+| Method | Input source | Status |
+|---|---|---|
+| Paste the opt-in sentence | User prompt | Tested reference path; no extra install |
+| Invoke `/pilotfish <task>` | [User-invocable skill](https://code.claude.com/docs/en/slash-commands#control-who-invokes-a-skill) with the task in `$ARGUMENTS` | Recommended shortcut; closest to the tested user-prompt path |
+| Start `claude-pilotfish` | [`--append-system-prompt`](https://code.claude.com/docs/en/cli-usage#system-prompt-flags) adds one session instruction | Optional CLI wrapper; explicit launch, different prompt surface |
+| Model-selected `pilotfish-auto` | Model invokes an always-visible skill | Not shipped; experiment tracked in [#53](https://github.com/Nanako0129/pilotfish/issues/53) |
+| `UserPromptSubmit` hook | [Hook context](https://code.claude.com/docs/en/hooks#userpromptsubmit) wrapped as a system reminder | Not offered; it is not equivalent to a user request and may trigger prompt-injection defenses |
+
+The `/pilotfish` skill uses `disable-model-invocation: true`, so Claude cannot
+activate it for the user. The wrapper is also explicit because the user chooses
+to start that launcher, but its instruction reaches Claude as an appended system
+prompt rather than a user message.
+
+## Install with AI
+
+Clone a reviewed release, start Claude Code from that checkout, and paste:
+
+```text
+Read the local file install/ACTIVATION-INSTALL.md in the current checkout and
+follow its AI install contract. Ask me to choose the /pilotfish skill, the CLI
+wrapper, or both; for the wrapper, ask whether to include the optional Baton
+hint. Show me the complete plan and get my approval before writing anything.
+```
+
+### Shared AI install contract
+
+Resolve the configuration root exactly as Step 0 of
+[AGENT-INSTALL.md](./AGENT-INSTALL.md) specifies. Use the resolved root as
+`$CFG`; do not assume `~/.claude` when `CLAUDE_CONFIG_DIR` is set. Verify that
+the pilotfish marker block and eight role agents are already installed.
+
+Ask which shortcut to install. For a wrapper, ask whether to use the plain or
+Baton-aware prompt. The Baton-aware choice requires an already installed
+[Baton](https://github.com/cablate/baton) skill; this runbook never installs or
+updates Baton.
+
+Inspect every selected target before writing. Show its existing state, proposed
+content, update behavior, verification, and rollback, then wait for approval.
+Never overwrite an existing target that lacks the matching
+`pilotfish-activation` ownership marker. Stop and ask the user to keep it,
+remove it themselves, or choose another wrapper name or target.
+
+Before updating a marked Pilotfish-owned target, copy its exact bytes to a new
+timestamped file under `$CFG/backups/pilotfish-activation/history/`, read it
+back, compare it with the current target, and record its path. For a wrapper,
+also record its executable state. If creating or verifying the history backup
+fails, stop without modifying the target. Never reuse or overwrite an earlier
+backup. History backups support an explicit update rollback; they are never
+restored by uninstall.
+
+### `/pilotfish` skill payload
+
+Inspect `$CFG/skills/pilotfish/SKILL.md` and the legacy
+`$CFG/commands/pilotfish.md` for a name collision. Do not modify a legacy
+command; stop until the user resolves that collision. After approval, create
+only `$CFG/skills/pilotfish/SKILL.md` with these exact contents:
+
+```markdown
+---
+name: pilotfish
+description: Explicitly activate the installed pilotfish orchestration policy for one task.
+argument-hint: "<task>"
+disable-model-invocation: true
+---
+
+<!-- pilotfish-activation-skill -->
+
+Use pilotfish. Follow its dispatch brake: keep direct work in the main session
+and call the named agents only when the policy selects delegation.
+
+Complete this task:
+
+$ARGUMENTS
+
+If no task was supplied, ask the user for it before starting work.
+```
+
+### CLI wrapper payload
+
+Use the plain session instruction by default:
+
+```text
+The user explicitly authorizes Agent delegation for this session. Follow the installed pilotfish policy and its dispatch brake.
+```
+
+Use this variant only when the user selected Baton and the skill is already
+installed:
+
+```text
+The user explicitly authorizes Agent delegation for this session. Follow the installed pilotfish policy and its dispatch brake. If Baton is installed, use it as the delegation-planning layer when its planning benefit exceeds coordination cost.
+```
+
+Choose an existing user-owned directory already present in `PATH`. Do not edit a
+shell profile or change `PATH`; if no suitable directory exists, stop and show
+the direct command from [Use and verify](#use-and-verify) instead.
+
+On macOS, Linux, or WSL, install `claude-pilotfish` with the selected instruction
+substituted for `<SESSION_INSTRUCTION>`, then make the file executable:
+
+```sh
+#!/bin/sh
+# pilotfish-activation-wrapper
+exec claude --append-system-prompt '<SESSION_INSTRUCTION>' "$@"
+```
+
+On native Windows, install `claude-pilotfish.cmd` in an existing user-owned
+`PATH` directory:
+
+```bat
+@echo off
+REM pilotfish-activation-wrapper
+claude --append-system-prompt "<SESSION_INSTRUCTION>" %*
+```
+
+Read every installed target back and compare its complete contents with the
+selected payload. Run `claude-pilotfish --version` to confirm wrapper lookup,
+argument forwarding, and executable state without starting a paid Claude
+session. Report every backup path. Do not modify `settings.json`, the eight role
+agents, the pilotfish policy block, Baton, shell profiles, or `PATH`.
+
+## Use and verify
+
+Claude Code supports [live skill change detection](https://code.claude.com/docs/en/slash-commands#live-change-detection).
+Open `/skills` and confirm that `pilotfish` is visible, or start a new session
+if the current one does not pick it up. Invoke it at the start of a task:
+
+```text
+/pilotfish migrate the cache schema without changing the public API
+```
+
+Start a wrapper-installed session with:
+
+```sh
+claude-pilotfish
+```
+
+Without installing a wrapper, the plain one-off command is:
+
+```sh
+claude --append-system-prompt "The user explicitly authorizes Agent delegation for this session. Follow the installed pilotfish policy and its dispatch brake."
+```
+
+Both methods authorize pilotfish to apply its dispatch brake; neither requires
+delegation. Small or tightly coupled work may remain in the main session, and
+higher-priority managed policy can still block Agent use.
+
+## Update or remove
+
+Re-run the AI install prompt to compare selected targets with this reviewed
+file. For an explicit update rollback, restore the selected history backup and
+verify its bytes and wrapper executable state. For uninstall, remove only a
+target that carries the matching ownership marker and still matches a reviewed
+Pilotfish payload. Never restore a history backup during uninstall. Stop and
+show a diff if current content has changed. Because this runbook never replaces
+unowned content, uninstall has no pre-Pilotfish file to restore. The core
+pilotfish and optional Baton installations remain unchanged.


### PR DESCRIPTION
## Summary

Turn the English and Traditional Chinese READMEs into concise project entrypoints while keeping installation, trust, dispatch, role topology, and removal guidance visible.

Move detailed operation into paired usage guides and add an optional activation guide for explicit `/pilotfish` tasks or a session-scoped `claude-pilotfish` wrapper. Both shortcuts remain deliberate user opt-ins, not cue-free dispatch.

## Changes

| Area | Result |
|---|---|
| Root READMEs | Shorter overview, complete eight-role Mermaid topology, pinned install path, trust warning, explicit delegation caveat, and compact navigation |
| Usage guides | English and Traditional Chinese references for model routing, compatibility, tuning, long runs, verification, removal, and optional activation |
| Activation | Reviewed `/pilotfish` skill payload, minimal CLI wrapper, optional already-installed Baton hint, and approval-gated AI install contract |
| Install safety | Configuration-root resolution, ownership markers, fail-closed collisions, verified update-history backups, and uninstall without obsolete-version restoration |
| Evidence | Direct links to dispatch-brake, spontaneous-dispatch, Baton activation, prompt-compression, and verifier-boundary records |
| Future experiment | Model-invoked `pilotfish-auto` is not shipped; routine, bug, mechanical, and schema evaluation is tracked in #53 |
| Attribution | Explicit prior-art credit for Anthropic managed agents, `opusplan`, and Rylaa/fable5-orchestrator in the design notes |

## Validation

| Check | Result |
|---|---|
| Unit tests | 38/38 passed |
| Repository-relative links and anchors | 100 checked, 0 failures |
| Whitespace validation | `git diff --check` passed |
| Wrapper validation | POSIX syntax and no-session `--version` lookup passed |
| Fresh completed-work reviews | README result `CONFIRMED`; activation update/uninstall lifecycle `CONFIRMED` |

No runtime policy, role-agent template, core installer, or benchmark artifact changes are included.
