### PR TITLE
docs: link activation guide from READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ in [install/AGENT-INSTALL.md](./install/AGENT-INSTALL.md).
 | Task | Where to go |
 |---|---|
 | Tune models, effort, delegation, or managed settings | [Usage guide](./docs/usage.md) |
+| Activate pilotfish for a task or session | [Install `/pilotfish` or the CLI wrapper](./install/ACTIVATION-INSTALL.md) |
 | Update an existing install | [Runbook: Updating an existing install](./install/AGENT-INSTALL.md#updating-an-existing-install) |
 | Review release changes | [CHANGELOG.md](./CHANGELOG.md) |
 | Disable pilotfish for one project | Use a separate `CLAUDE_CONFIG_DIR`; details are in the [usage guide](./docs/usage.md#disable-update-or-uninstall) |

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -139,6 +139,7 @@ verification、更新與移除都在 [install/AGENT-INSTALL.md](./install/AGENT-
 | 任務 | 文件或方法 |
 |---|---|
 | 調整模型、effort、委派或 managed settings | [使用指南](./docs/usage.zh-TW.md) |
+| 為單一任務或 session 啟用 pilotfish | [安裝 `/pilotfish` 或 CLI wrapper](./install/ACTIVATION-INSTALL.md) |
 | 更新既有安裝 | [Runbook：Updating an existing install](./install/AGENT-INSTALL.md#updating-an-existing-install) |
 | 查看版本變更 | [CHANGELOG.md](./CHANGELOG.md) |
 | 只對一個專案停用 | 使用另一個 `CLAUDE_CONFIG_DIR`；詳見 [使用指南](./docs/usage.zh-TW.md#停用更新或移除) |


### PR DESCRIPTION
## Summary

Add a direct activation-guide entry to the English and Traditional Chinese README operation tables.

Users can now reach the optional `/pilotfish` skill and CLI-wrapper installation instructions without first navigating through the general usage guide.

## Validation

- 38/38 unit tests passed
- `git diff --check` passed
- `install/ACTIVATION-INSTALL.md` exists at both linked paths

Documentation navigation only; no runtime policy or installer behavior changes.
