### PR TITLE
feat(benchmarks): add attempt accounting ledger

### DIFF
--- a/benchmarks/attempt-accounting.json
+++ b/benchmarks/attempt-accounting.json
@@ -540,6 +540,14 @@
         {
           "source": "benchmarks/prompt-compression/results.json",
           "json_pointer": "/behavioral_gates/small_lifecycle"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/small_lifecycle/turn_1_plan"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/small_lifecycle/turn_2_approved_execution"
         }
       ],
       "attempt_pointers": [
@@ -549,12 +557,16 @@
         },
         {
           "source": "benchmarks/prompt-compression/results.json",
-          "json_pointer": "/behavioral_gates/small_lifecycle"
+          "json_pointer": "/behavioral_gates/small_lifecycle/turn_1_plan"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/small_lifecycle/turn_2_approved_execution"
         }
       ],
       "count_status": "known",
-      "attempted": 2,
-      "passed": 2,
+      "attempted": 3,
+      "passed": 3,
       "failed": 0
     },
     {
@@ -572,6 +584,10 @@
         {
           "source": "benchmarks/prompt-compression/results.json",
           "json_pointer": "/behavioral_gates/explicit_lifecycle_turn_1"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/explicit_lifecycle_user_continuation"
         }
       ],
       "attempt_pointers": [
@@ -586,12 +602,16 @@
         {
           "source": "benchmarks/prompt-compression/results.json",
           "json_pointer": "/behavioral_gates/explicit_lifecycle_turn_1"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/explicit_lifecycle_user_continuation"
         }
       ],
       "count_status": "known",
-      "attempted": 3,
+      "attempted": 4,
       "passed": 0,
-      "failed": 3
+      "failed": 4
     },
     {
       "id": "cell:benchmarks/prompt-compression/results.json#not_run",
@@ -612,35 +632,6 @@
       "passed": 0,
       "failed": 0,
       "reason": "Source explicitly records no behavioral invocation ran for these records."
-    },
-    {
-      "id": "cell:benchmarks/prompt-compression/results.json#unknown",
-      "claim_status": "unknown",
-      "claim_pointers": [
-        {
-          "source": "benchmarks/prompt-compression/results.json",
-          "json_pointer": "/behavioral_gates/explicit_lifecycle_user_continuation"
-        },
-        {
-          "source": "benchmarks/prompt-compression/results.json",
-          "json_pointer": "/behavioral_gates/small_lifecycle/turn_1_plan"
-        },
-        {
-          "source": "benchmarks/prompt-compression/results.json",
-          "json_pointer": "/behavioral_gates/small_lifecycle/turn_2_approved_execution"
-        }
-      ],
-      "attempt_pointers": [
-        {
-          "source": "benchmarks/prompt-compression/results.json",
-          "json_pointer": "/behavioral_gates/explicit_lifecycle_user_continuation"
-        }
-      ],
-      "count_status": "unknown",
-      "attempted": null,
-      "passed": null,
-      "failed": null,
-      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
     },
     {
       "id": "cell:benchmarks/spontaneous-dispatch/results.json#passed",
@@ -2013,6 +2004,25 @@
           "source": "benchmarks/prompt-compression/results.json",
           "json_pointer": "/behavioral_gates/explicit_lifecycle_turn_1",
           "raw_stream_sha256": "e1d80d3dcddb285a41c3eb1a301688463a4aef93c9afc45be6ab6bd5d43fe8c6"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/prompt-compression/results.json#/behavioral_gates/explicit_lifecycle_user_continuation",
+      "cell_id": "cell:benchmarks/prompt-compression/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/prompt-compression/results.json",
+        "json_pointer": "/behavioral_gates/explicit_lifecycle_user_continuation"
+      },
+      "candidate_identity": {
+        "version": "1.3.4"
+      },
+      "failure_boundary": "status=revise",
+      "evidence": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/explicit_lifecycle_user_continuation",
+          "raw_stream_sha256": "177b1ec882daca159529e58130e9a341dc2b54ab5a7e8a34521d99f0d2e01687"
         }
       ]
     },

--- a/benchmarks/attempt-accounting.json
+++ b/benchmarks/attempt-accounting.json
@@ -1590,17 +1590,29 @@
         },
         {
           "source": "benchmarks/verifier-boundary/results.json",
-          "json_pointer": "/failed_attempts/2"
+          "json_pointer": "/failed_attempts/2",
+          "occurrence": 0
         },
         {
           "source": "benchmarks/verifier-boundary/results.json",
-          "json_pointer": "/failed_attempts/3"
+          "json_pointer": "/failed_attempts/2",
+          "occurrence": 1
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/3",
+          "occurrence": 0
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/3",
+          "occurrence": 1
         }
       ],
       "count_status": "known",
-      "attempted": 4,
+      "attempted": 6,
       "passed": 0,
-      "failed": 4
+      "failed": 6
     },
     {
       "id": "cell:benchmarks/verifier-boundary/results.json#unknown",
@@ -1723,7 +1735,8 @@
         "json_pointer": "/failed_candidate_gate/turns/0"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "d41a9d41db21e97176e82614dcfd4d80cba670ec28136666cc96906dd5efda35",
+        "version": "1.3.0"
       },
       "failure_boundary": "failure_reasons=nonempty; failure_summary=nonempty",
       "evidence": [
@@ -1742,7 +1755,7 @@
         "json_pointer": "/large_policy_activation_gate/attempts/0"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "46155d17c9d78c5fb567571ece0928e1515d04ea9ef98aaaaec5688a81e7b614"
       },
       "failure_boundary": "status=activation_dispatch_pass_ownership_fail; failure=nonempty",
       "evidence": [
@@ -1761,7 +1774,7 @@
         "json_pointer": "/large_policy_activation_gate/attempts/1"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "153d30aa3032033f3a6368a0a77a6d37b43f2e4e9d97a5a8689c24d1472bdf6b"
       },
       "failure_boundary": "status=activation_dispatch_parallel_launch_pass_ownership_fail; failure=nonempty",
       "evidence": [
@@ -1780,7 +1793,7 @@
         "json_pointer": "/large_policy_activation_gate/attempts/2"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "17d272b6ddd6d95a749a802f5e29dfd4625c884f8a84bf817ffc20bfca6b39bf"
       },
       "failure_boundary": "test_passed=false; status=topology_pass_runtime_limit_outcome_incomplete; failure=nonempty",
       "evidence": [
@@ -1894,7 +1907,7 @@
         "json_pointer": "/behavioral_gates/spontaneous_mechanical_candidate"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "version": "1.3.4"
       },
       "failure_boundary": "status=correctness_passed_topology_blocked",
       "evidence": [
@@ -1913,7 +1926,7 @@
         "json_pointer": "/behavioral_gates/spontaneous_mechanical_v1_3_3_control"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "version": "1.3.3"
       },
       "failure_boundary": "status=correctness_passed_same_topology_blocker",
       "evidence": [
@@ -1932,7 +1945,7 @@
         "json_pointer": "/behavioral_gates/explicit_lifecycle_turn_1"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "version": "1.3.4"
       },
       "failure_boundary": "status=stopped_after_two_revise",
       "evidence": [
@@ -1951,7 +1964,7 @@
         "json_pointer": "/runs/1"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "version": "1.3.0"
       },
       "failure_boundary": "status=success_topology_fail",
       "evidence": [
@@ -2055,7 +2068,7 @@
         "json_pointer": "/attempts/0"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.7-opus5-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2074,7 +2087,7 @@
         "json_pointer": "/attempts/1"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.7-opus5-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2093,7 +2106,7 @@
         "json_pointer": "/attempts/2"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "candidate-1-opus5-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2112,7 +2125,7 @@
         "json_pointer": "/attempts/3"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "candidate-1-opus5-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2131,7 +2144,7 @@
         "json_pointer": "/attempts/4"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "candidate-2-opus5-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2150,7 +2163,7 @@
         "json_pointer": "/attempts/5"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "candidate-2-opus5-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2169,7 +2182,7 @@
         "json_pointer": "/attempts/8"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.1-opus5-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2188,7 +2201,7 @@
         "json_pointer": "/attempts/9"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.1-opus5-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2207,7 +2220,7 @@
         "json_pointer": "/attempts/10"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.1-opus4.8-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2226,7 +2239,7 @@
         "json_pointer": "/attempts/11"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.1-opus4.8-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2245,7 +2258,7 @@
         "json_pointer": "/attempts/12"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.7-opus4.8-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2264,7 +2277,7 @@
         "json_pointer": "/attempts/13"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.7-opus4.8-2.1.220"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2283,7 +2296,7 @@
         "json_pointer": "/attempts/19"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "config": "v1.3.1-opus4.8-2.1.218-release-roles"
       },
       "failure_boundary": "reachability=FAIL",
       "evidence": [
@@ -2302,7 +2315,7 @@
         "json_pointer": "/failed_attempts/0"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "version": "1.3.7"
       },
       "failure_boundary": "status=rejected_quota_exhausted",
       "evidence": [
@@ -2320,7 +2333,7 @@
         "json_pointer": "/failed_attempts/1"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "version": "1.3.7"
       },
       "failure_boundary": "status=rejected_operator_contract_blocked_agents",
       "evidence": [
@@ -2336,16 +2349,38 @@
       "cell_id": "cell:benchmarks/verifier-boundary/results.json#failed",
       "attempt_pointer": {
         "source": "benchmarks/verifier-boundary/results.json",
-        "json_pointer": "/failed_attempts/2"
+        "json_pointer": "/failed_attempts/2",
+        "occurrence": 0
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "59f18c6dd85cd92a6797bf691bb8ee1c372587b08e419991430955877d4e64ba"
       },
       "failure_boundary": "reviewed_failure=compressed-candidate-schema-non-reproduction",
       "evidence": [
         {
           "source": "benchmarks/verifier-boundary/results.json",
-          "json_pointer": "/failed_attempts/2"
+          "json_pointer": "/failed_attempts/2",
+          "occurrence": 0
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/verifier-boundary/results.json#/failed_attempts/2#occurrence-1",
+      "cell_id": "cell:benchmarks/verifier-boundary/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/verifier-boundary/results.json",
+        "json_pointer": "/failed_attempts/2",
+        "occurrence": 1
+      },
+      "candidate_identity": {
+        "hash": "59f18c6dd85cd92a6797bf691bb8ee1c372587b08e419991430955877d4e64ba"
+      },
+      "failure_boundary": "inconclusive_diagnostic=nonempty",
+      "evidence": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/2",
+          "occurrence": 1
         }
       ]
     },
@@ -2354,16 +2389,40 @@
       "cell_id": "cell:benchmarks/verifier-boundary/results.json#failed",
       "attempt_pointer": {
         "source": "benchmarks/verifier-boundary/results.json",
-        "json_pointer": "/failed_attempts/3"
+        "json_pointer": "/failed_attempts/3",
+        "occurrence": 0
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "6b1e809551ebe776bfca3543c8e17d78383f23301497d95904d9725b727e16d4"
       },
       "failure_boundary": "reviewed_failure=uncollected-background-verification",
       "evidence": [
         {
           "source": "benchmarks/verifier-boundary/results.json",
-          "json_pointer": "/failed_attempts/3"
+          "json_pointer": "/failed_attempts/3",
+          "occurrence": 0,
+          "raw_stream_sha256": "594791006d663210ab943a0ee2dffee170e6cb3dea9a7a6af8b801ae32182737"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/verifier-boundary/results.json#/failed_attempts/3#occurrence-1",
+      "cell_id": "cell:benchmarks/verifier-boundary/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/verifier-boundary/results.json",
+        "json_pointer": "/failed_attempts/3",
+        "occurrence": 1
+      },
+      "candidate_identity": {
+        "hash": "6b1e809551ebe776bfca3543c8e17d78383f23301497d95904d9725b727e16d4"
+      },
+      "failure_boundary": "reviewed_failure=uncollected-background-verification",
+      "evidence": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/3",
+          "occurrence": 1,
+          "raw_stream_sha256": "f927d03834ba431858ed4e508fdd5714a8eaa309f0f23ab05bedbbe6da15d66b"
         }
       ]
     }

--- a/benchmarks/attempt-accounting.json
+++ b/benchmarks/attempt-accounting.json
@@ -1,0 +1,2371 @@
+{
+  "schema_version": 1,
+  "sources": [
+    {
+      "path": "benchmarks/baton-compatibility/results.json",
+      "sha256": "fd4c9271035f3f43aad8f7b51b69a831e7a62709c2d255a9c987b040308ac170"
+    },
+    {
+      "path": "benchmarks/baton-dispatch-effect/results.json",
+      "sha256": "d5ef8cef7956cb0a0cdf84582f900c130ebfef32228fc1fb3e9fa91d9fdce713"
+    },
+    {
+      "path": "benchmarks/dispatch-brake/results.json",
+      "sha256": "4db849669b49386911ded403352b857d2341fe147f0223f262d34d1d04bc17df"
+    },
+    {
+      "path": "benchmarks/dispatch-brake/positive-controls/results.json",
+      "sha256": "f8bb489168cc387b9f51db4d5a4095316e0714e7b7fd328fcbbd691c060b269b"
+    },
+    {
+      "path": "benchmarks/prompt-compression/results.json",
+      "sha256": "7d5b15d20711b1f17b7e4b6ce727d02fb6a513abd3ea3eff8317a28d39e0904a"
+    },
+    {
+      "path": "benchmarks/spontaneous-dispatch/results.json",
+      "sha256": "6bb766753fc98036a92a8e02e0573e87f46e991e22065f6dee962ce90cc45c44"
+    },
+    {
+      "path": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+      "sha256": "ac3f4dabaabb17f3519d27f7841b1c144de347854df2efdd6746016668ca41a2"
+    },
+    {
+      "path": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+      "sha256": "0e8eae3338f2ee0e913ffc22c39770403ef4d49081d865bdd296b4b7a9854b81"
+    },
+    {
+      "path": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+      "sha256": "032685e4b9f928f1e92f1b99d9c3739352860f7c4d84dc4d8f2f4f402b5d126c"
+    },
+    {
+      "path": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+      "sha256": "bf9e493f21f46a60ad7ba416fd57a361e6733aba2f6607fbbf75d0cbca0b36d8"
+    },
+    {
+      "path": "benchmarks/verifier-boundary/results.json",
+      "sha256": "574fe0dcc78e0abf4faf4fb6895ecc7cf5fba964f3fbb0b6987f5d4779f87430"
+    }
+  ],
+  "coverage_exclusions": [
+    {
+      "source": "benchmarks/prompt-compression/results.json",
+      "json_pointer": "/context_census",
+      "reason": "static context census, not a behavioral invocation"
+    },
+    {
+      "source": "benchmarks/prompt-compression/results.json",
+      "json_pointer": "/paid_campaign",
+      "reason": "campaign bookkeeping, not a behavioral invocation"
+    },
+    {
+      "source": "benchmarks/prompt-compression/results.json",
+      "json_pointer": "/static_gate",
+      "reason": "static byte/policy gate, not a behavioral invocation"
+    }
+  ],
+  "cells": [
+    {
+      "id": "cell:benchmarks/baton-compatibility/results.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/previous_final_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/previous_final_gate/turns/1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/final_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/final_gate/turns/1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_release_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_release_gate/turns/1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_release_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_release_gate/turns/1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_release_gate/turns/2"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_candidate_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_candidate_gate/turns/2"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/previous_final_gate/turns/1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/final_gate/turns/1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_release_gate/turns/1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_release_gate/turns/1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_release_gate/turns/2"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_candidate_gate/turns/2"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 6,
+      "passed": 6,
+      "failed": 0
+    },
+    {
+      "id": "cell:benchmarks/baton-compatibility/results.json#failed",
+      "claim_status": "failed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/failed_candidate_gate"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/failed_candidate_gate/turns/0"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 2,
+      "passed": 0,
+      "failed": 2
+    },
+    {
+      "id": "cell:benchmarks/baton-compatibility/results.json#unknown",
+      "claim_status": "unknown",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/turn_1"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/previous_release_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/historical_release_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/rejected_harness_run"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/previous_final_gate/turns/0"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/final_gate/turns/0"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_release_gate/turns/0"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_release_gate/turns/0"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_candidate_gate/turns/0"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_candidate_gate/turns/1"
+        }
+      ],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    },
+    {
+      "id": "cell:benchmarks/baton-dispatch-effect/results.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/small_availability_observation/cells/0"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/small_availability_observation/cells/1"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/small_availability_observation/gate"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/3"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/3/in_session_test"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/effect_gate"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/release_payload_replay"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/release_payload_replay/in_session_test"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/release_payload_replay/effect_gate"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/small_availability_observation/cells/0"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/small_availability_observation/cells/1"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/3"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/release_payload_replay"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 4,
+      "passed": 4,
+      "failed": 0
+    },
+    {
+      "id": "cell:benchmarks/baton-dispatch-effect/results.json#failed",
+      "claim_status": "failed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/0"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/1"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/2"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/0"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/1"
+        },
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/2"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 3,
+      "passed": 0,
+      "failed": 3
+    },
+    {
+      "id": "cell:benchmarks/dispatch-brake/results.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/0"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/1"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/2"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/3"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/4"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/5"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/0"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/1"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/2"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/3"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/4"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/results.json",
+          "json_pointer": "/runs/5"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 6,
+      "passed": 6,
+      "failed": 0
+    },
+    {
+      "id": "cell:benchmarks/dispatch-brake/positive-controls/results.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/0"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/2"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/3"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/4"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/5"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/6"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/7"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/8"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/0"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/2"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/3"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/4"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/5"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/6"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/7"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/8"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 8,
+      "passed": 8,
+      "failed": 0
+    },
+    {
+      "id": "cell:benchmarks/dispatch-brake/positive-controls/results.json#failed",
+      "claim_status": "failed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/1"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/0"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/1"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/2"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/3"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/1"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/0"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/1"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/2"
+        },
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/3"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 5,
+      "passed": 0,
+      "failed": 5
+    },
+    {
+      "id": "cell:benchmarks/prompt-compression/results.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/spontaneous_bug_candidate"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/small_lifecycle"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/spontaneous_bug_candidate"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/small_lifecycle"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 2,
+      "passed": 2,
+      "failed": 0
+    },
+    {
+      "id": "cell:benchmarks/prompt-compression/results.json#failed",
+      "claim_status": "failed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/spontaneous_mechanical_candidate"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/spontaneous_mechanical_v1_3_3_control"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/explicit_lifecycle_turn_1"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/spontaneous_mechanical_candidate"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/spontaneous_mechanical_v1_3_3_control"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/explicit_lifecycle_turn_1"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 3,
+      "passed": 0,
+      "failed": 3
+    },
+    {
+      "id": "cell:benchmarks/prompt-compression/results.json#not_run",
+      "claim_status": "not_run",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/baton_large"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/gap_roles"
+        }
+      ],
+      "attempt_pointers": [],
+      "count_status": "known",
+      "attempted": 0,
+      "passed": 0,
+      "failed": 0,
+      "reason": "Source explicitly records no behavioral invocation ran for these records."
+    },
+    {
+      "id": "cell:benchmarks/prompt-compression/results.json#unknown",
+      "claim_status": "unknown",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/explicit_lifecycle_user_continuation"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/small_lifecycle/turn_1_plan"
+        },
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/small_lifecycle/turn_2_approved_execution"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/explicit_lifecycle_user_continuation"
+        }
+      ],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/results.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/3"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/4"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/5"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/3"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/4"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/5"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 4,
+      "passed": 4,
+      "failed": 0
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/results.json#failed",
+      "claim_status": "failed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/1"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/1"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 1,
+      "passed": 0,
+      "failed": 1
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/results.json#not_run",
+      "claim_status": "not_run",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/0"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/0"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 0,
+      "passed": 0,
+      "failed": 0,
+      "reason": "Source explicitly records no behavioral invocation ran for these records."
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/results.json#unknown",
+      "claim_status": "unknown",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_paired_opt_in_matrix"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_paired_opt_in_matrix/cue_free/pro"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_paired_opt_in_matrix/cue_free/max"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/1"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/1"
+        }
+      ],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": ""
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/routine_docs"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/single_unknown_bug"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/mechanical_repetition"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/schema_lifecycle"
+        }
+      ],
+      "attempt_pointers": [],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json#unknown",
+      "claim_status": "unknown",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/0/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/0/turn_2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/1/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/1/turn_2"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/1"
+        }
+      ],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/cue-free-tui.json#failed",
+      "claim_status": "failed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": ""
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/tui_observation"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/3"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/3"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 4,
+      "passed": 0,
+      "failed": 4
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/issue-29-recovery.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": ""
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/routine_docs"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/single_unknown_bug"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/mechanical_repetition"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/schema_lifecycle"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/routine_docs"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/single_unknown_bug"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/mechanical_repetition"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/schema_lifecycle"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/routine_docs"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/single_unknown_bug"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/mechanical_repetition"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/schema_lifecycle"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/routine_docs"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/single_unknown_bug"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/mechanical_repetition"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/schema_lifecycle"
+        }
+      ],
+      "attempt_pointers": [],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/issue-29-recovery.json#unknown",
+      "claim_status": "unknown",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/mechanical_repetition/budget_incomplete_diagnostic"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/0/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/0/turn_2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/1/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/1/turn_2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/schema_lifecycle/attempts/0/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/schema_lifecycle/attempts/0/turn_2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/schema_lifecycle/attempts/1/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/schema_lifecycle/attempts/1/turn_2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/schema_lifecycle/attempts/0/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/schema_lifecycle/attempts/0/turn_2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/schema_lifecycle/attempts/1/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/schema_lifecycle/attempts/1/turn_2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/schema_lifecycle/attempts/0/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/schema_lifecycle/attempts/0/turn_2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/schema_lifecycle/attempts/1/turn_1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/schema_lifecycle/attempts/1/turn_2"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/results/schema_lifecycle/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/schema_lifecycle/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/release_replay/results/schema_lifecycle/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/schema_lifecycle/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_gate/results/schema_lifecycle/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/routine_docs/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/routine_docs/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/single_unknown_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/single_unknown_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/mechanical_repetition/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/mechanical_repetition/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/schema_lifecycle/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+          "json_pointer": "/adaptive_interaction_routing_post_review_gate/results/schema_lifecycle/attempts/1"
+        }
+      ],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/6"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/7"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/14"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/15"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/16"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/17"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/18"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/6"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/7"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/14"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/15"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/16"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/17"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/18"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 7,
+      "passed": 7,
+      "failed": 0
+    },
+    {
+      "id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "claim_status": "failed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/3"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/4"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/5"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/8"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/9"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/10"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/11"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/12"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/13"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/19"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/2"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/3"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/4"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/5"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/8"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/9"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/10"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/11"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/12"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/13"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/19"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 13,
+      "passed": 0,
+      "failed": 13
+    },
+    {
+      "id": "cell:benchmarks/verifier-boundary/results.json#passed",
+      "claim_status": "passed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate"
+        }
+      ],
+      "attempt_pointers": [],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    },
+    {
+      "id": "cell:benchmarks/verifier-boundary/results.json#failed",
+      "claim_status": "failed",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/0"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/1"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/3"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/0"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/1"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/2"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/3"
+        }
+      ],
+      "count_status": "known",
+      "attempted": 4,
+      "passed": 0,
+      "failed": 4
+    },
+    {
+      "id": "cell:benchmarks/verifier-boundary/results.json#unknown",
+      "claim_status": "unknown",
+      "claim_pointers": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/historical_candidate_gate"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/schema_lifecycle/attempt_a/turn_1"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/schema_lifecycle/attempt_a/turn_2"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/schema_lifecycle/attempt_b/turn_1"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/schema_lifecycle/attempt_b/turn_2"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/routine_docs_control"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/post_cap_plan_control"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/schema_lifecycle/turn_1"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/schema_lifecycle/turn_2"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/routine_docs_control"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/post_cap_plan_control/turns/0"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/post_cap_plan_control/turns/1"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/post_cap_plan_control/turns/2"
+        }
+      ],
+      "attempt_pointers": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/schema_lifecycle/attempt_a"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/schema_lifecycle/attempt_b"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/routine_docs_control"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/passing_gate/post_cap_plan_control"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/schema_lifecycle"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/routine_docs_control"
+        },
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/superseded_v1_3_6_passing_gate/post_cap_plan_control"
+        }
+      ],
+      "count_status": "unknown",
+      "attempted": null,
+      "passed": null,
+      "failed": null,
+      "reason": "Attempt pointers are absent or include records without an explicit per-attempt outcome; counts are not inferred from aggregate evidence."
+    }
+  ],
+  "failed_attempts": [
+    {
+      "id": "failure:benchmarks/baton-compatibility/results.json#/v1_3_2_opus5_rejected_user_source_attempt",
+      "cell_id": "cell:benchmarks/baton-compatibility/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/baton-compatibility/results.json",
+        "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "passed=false; status=rejected",
+      "evidence": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/baton-compatibility/results.json#/failed_candidate_gate/turns/0",
+      "cell_id": "cell:benchmarks/baton-compatibility/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/baton-compatibility/results.json",
+        "json_pointer": "/failed_candidate_gate/turns/0"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "failure_reasons=nonempty; failure_summary=nonempty",
+      "evidence": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/failed_candidate_gate",
+          "transcript_sha256": "250b8cd8b53e758299b233d16c2753890a46c6284a99a8d21ba5d5e907bf7ebc"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/baton-dispatch-effect/results.json#/large_policy_activation_gate/attempts/0",
+      "cell_id": "cell:benchmarks/baton-dispatch-effect/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/baton-dispatch-effect/results.json",
+        "json_pointer": "/large_policy_activation_gate/attempts/0"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=activation_dispatch_pass_ownership_fail; failure=nonempty",
+      "evidence": [
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/0",
+          "raw_stream_sha256": "c9a275036928636ec0c1887ac718fc38744571caf1001b410e5e7aa5511266f0"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/baton-dispatch-effect/results.json#/large_policy_activation_gate/attempts/1",
+      "cell_id": "cell:benchmarks/baton-dispatch-effect/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/baton-dispatch-effect/results.json",
+        "json_pointer": "/large_policy_activation_gate/attempts/1"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=activation_dispatch_parallel_launch_pass_ownership_fail; failure=nonempty",
+      "evidence": [
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/1",
+          "raw_stream_sha256": "281aeef1943de2f0696afd6a0ff85234a53462ca1653ec80932403cf4a8e0f60"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/baton-dispatch-effect/results.json#/large_policy_activation_gate/attempts/2",
+      "cell_id": "cell:benchmarks/baton-dispatch-effect/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/baton-dispatch-effect/results.json",
+        "json_pointer": "/large_policy_activation_gate/attempts/2"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "test_passed=false; status=topology_pass_runtime_limit_outcome_incomplete; failure=nonempty",
+      "evidence": [
+        {
+          "source": "benchmarks/baton-dispatch-effect/results.json",
+          "json_pointer": "/large_policy_activation_gate/attempts/2",
+          "raw_stream_sha256": "f7315489c29509dc31f8a5403a50ba28c1e84966a5ccb74bd8aca222fed4c8ed"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/dispatch-brake/positive-controls/results.json#/complete_runs/1",
+      "cell_id": "cell:benchmarks/dispatch-brake/positive-controls/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+        "json_pointer": "/complete_runs/1"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=error_max_budget_usd",
+      "evidence": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/complete_runs/1",
+          "raw_stream_sha256": "461dc2b7595384ef425276193a3fd3a73261f2f69353cc9254fecfc7af0edab9"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/dispatch-brake/positive-controls/results.json#/interrupted_policy_probes/0",
+      "cell_id": "cell:benchmarks/dispatch-brake/positive-controls/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+        "json_pointer": "/interrupted_policy_probes/0"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=error_during_execution",
+      "evidence": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/0",
+          "raw_stream_sha256": "b342e11e090df2594717c3029ef93692386d3ff984435c71da2331df85e5b7f3"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/dispatch-brake/positive-controls/results.json#/interrupted_policy_probes/1",
+      "cell_id": "cell:benchmarks/dispatch-brake/positive-controls/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+        "json_pointer": "/interrupted_policy_probes/1"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=error_during_execution",
+      "evidence": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/1",
+          "raw_stream_sha256": "d915599c1b34429610e19040789b71affeb40626ad5a402392cc36843848c026"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/dispatch-brake/positive-controls/results.json#/interrupted_policy_probes/2",
+      "cell_id": "cell:benchmarks/dispatch-brake/positive-controls/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+        "json_pointer": "/interrupted_policy_probes/2"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=error_during_execution",
+      "evidence": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/2",
+          "raw_stream_sha256": "3f16c74b56292f0f2f384537622cabdea82508a3fcf0444486c0f38b8006d90d"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/dispatch-brake/positive-controls/results.json#/interrupted_policy_probes/3",
+      "cell_id": "cell:benchmarks/dispatch-brake/positive-controls/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+        "json_pointer": "/interrupted_policy_probes/3"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=error_during_execution",
+      "evidence": [
+        {
+          "source": "benchmarks/dispatch-brake/positive-controls/results.json",
+          "json_pointer": "/interrupted_policy_probes/3",
+          "raw_stream_sha256": "084bcdfa3b2597a7e0526d53db05c24a771958c8727ed9720f19348e846495da"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/prompt-compression/results.json#/behavioral_gates/spontaneous_mechanical_candidate",
+      "cell_id": "cell:benchmarks/prompt-compression/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/prompt-compression/results.json",
+        "json_pointer": "/behavioral_gates/spontaneous_mechanical_candidate"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=correctness_passed_topology_blocked",
+      "evidence": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/spontaneous_mechanical_candidate",
+          "raw_stream_sha256": "b4bd11e88785a406c99c30f5c96328c7461cc19c0c6bfe8a7d7bc3a1313e55b8"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/prompt-compression/results.json#/behavioral_gates/spontaneous_mechanical_v1_3_3_control",
+      "cell_id": "cell:benchmarks/prompt-compression/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/prompt-compression/results.json",
+        "json_pointer": "/behavioral_gates/spontaneous_mechanical_v1_3_3_control"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=correctness_passed_same_topology_blocker",
+      "evidence": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/spontaneous_mechanical_v1_3_3_control",
+          "raw_stream_sha256": "c781e5c28409509fba487152f18f299520e7ba2fc55ca4beb4d16353d338a991"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/prompt-compression/results.json#/behavioral_gates/explicit_lifecycle_turn_1",
+      "cell_id": "cell:benchmarks/prompt-compression/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/prompt-compression/results.json",
+        "json_pointer": "/behavioral_gates/explicit_lifecycle_turn_1"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=stopped_after_two_revise",
+      "evidence": [
+        {
+          "source": "benchmarks/prompt-compression/results.json",
+          "json_pointer": "/behavioral_gates/explicit_lifecycle_turn_1",
+          "raw_stream_sha256": "e1d80d3dcddb285a41c3eb1a301688463a4aef93c9afc45be6ab6bd5d43fe8c6"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/results.json#/runs/1",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/results.json",
+        "json_pointer": "/runs/1"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=success_topology_fail",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/runs/1",
+          "raw_stream_sha256": "59e576004c8eae9e2d833307c4785f9b67013bf327f9c0d17b52a6e5a801dd23"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/cue-free-tui.json#/campaign/cells/0",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/cue-free-tui.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+        "json_pointer": "/campaign/cells/0"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "topology_pass=false",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": ""
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/tui_observation",
+          "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/0",
+          "raw_stream_sha256": "1450396041edf779d74783d275214ee396fc8d0723af305b26bae875470c27ce"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/cue-free-tui.json#/campaign/cells/1",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/cue-free-tui.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+        "json_pointer": "/campaign/cells/1"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "topology_pass=false",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/1",
+          "raw_stream_sha256": "84a6344cbb2864db20f3b0f00cdea680822c951c0d18dfec08db83e1420d6646"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/cue-free-tui.json#/campaign/cells/2",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/cue-free-tui.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+        "json_pointer": "/campaign/cells/2"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "topology_pass=false",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/2",
+          "raw_stream_sha256": "dec95adb7fb773d552223e23e32b1bcd03c3f7ba8475e44bcf6de606f25f7d83"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/cue-free-tui.json#/campaign/cells/3",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/cue-free-tui.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+        "json_pointer": "/campaign/cells/3"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "topology_pass=false",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/campaign/cells/3",
+          "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/0",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/0"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/0",
+          "raw_stream_sha256": "567577c4cce8bca9fccf84945c3f2d0cf4f77379cbfbc8e7949a31e0b8524d12"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/1",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/1"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/1",
+          "raw_stream_sha256": "806c11e6564b1f5799a869de6be587603f68e6b91df231b6079da29e71d22171"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/2",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/2"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/2",
+          "raw_stream_sha256": "68a5fb449755583a6ab44473f53b12540f78e7fc2b9f569f6d46556b48debc37"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/3",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/3"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/3",
+          "raw_stream_sha256": "c2298a0d2e427d2a6b16f42bcdb56c58deefb65742cc49a79dd368deefe802bb"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/4",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/4"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/4",
+          "raw_stream_sha256": "a41e3497606027ec0a8ea82cea54e763840c59b09a1f91ecc07e26fde0fac920"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/5",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/5"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/5",
+          "raw_stream_sha256": "675a924566c7ae8dd43b9ff43f038e0db42de53145909d8ff79140d7d0535b52"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/8",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/8"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/8",
+          "raw_stream_sha256": "5075874b6a7476839abd04c40b8f43417017eb74e32250e55b4fb3de3788308b"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/9",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/9"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/9",
+          "raw_stream_sha256": "db5a747ee8c6c072149d14e0a52c0c4253968da652948861b31e2a6a3b181e5d"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/10",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/10"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/10",
+          "raw_stream_sha256": "e5c0ad4abc4a626f77200b49bd00881ee6d83e5193a0db70927c069c22e044d6"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/11",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/11"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/11",
+          "raw_stream_sha256": "b36831c30be48590880879a7a150ac79a8cfdf8cf0028aec2786179e78f6137c"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/12",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/12"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/12",
+          "raw_stream_sha256": "e7b35ac2e426a7a722159f3f6450f93a795592faabd530b431c8e27a7a48b3c6"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/13",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/13"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/13",
+          "raw_stream_sha256": "4902a5b163dfb5c185d266f7195178467f2c7c28822ba948fdcedf02d3ca145b"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/issue-29-topology.json#/attempts/19",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/issue-29-topology.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+        "json_pointer": "/attempts/19"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reachability=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+          "json_pointer": "/attempts/19",
+          "raw_stream_sha256": "9861393a16a128470651d8f2f64fe6a207eec4451d315c320693e4a6545e0d20"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/verifier-boundary/results.json#/failed_attempts/0",
+      "cell_id": "cell:benchmarks/verifier-boundary/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/verifier-boundary/results.json",
+        "json_pointer": "/failed_attempts/0"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=rejected_quota_exhausted",
+      "evidence": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/0"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/verifier-boundary/results.json#/failed_attempts/1",
+      "cell_id": "cell:benchmarks/verifier-boundary/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/verifier-boundary/results.json",
+        "json_pointer": "/failed_attempts/1"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "status=rejected_operator_contract_blocked_agents",
+      "evidence": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/1",
+          "raw_stream_sha256": "9a6eaaa7f439ede5f4b2eb54856ea7446a3eeb18aef12a698362f399cd70b07e"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/verifier-boundary/results.json#/failed_attempts/2",
+      "cell_id": "cell:benchmarks/verifier-boundary/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/verifier-boundary/results.json",
+        "json_pointer": "/failed_attempts/2"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reviewed_failure=compressed-candidate-schema-non-reproduction",
+      "evidence": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/2"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/verifier-boundary/results.json#/failed_attempts/3",
+      "cell_id": "cell:benchmarks/verifier-boundary/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/verifier-boundary/results.json",
+        "json_pointer": "/failed_attempts/3"
+      },
+      "candidate_identity": {
+        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+      },
+      "failure_boundary": "reviewed_failure=uncollected-background-verification",
+      "evidence": [
+        {
+          "source": "benchmarks/verifier-boundary/results.json",
+          "json_pointer": "/failed_attempts/3"
+        }
+      ]
+    }
+  ]
+}

--- a/benchmarks/attempt-accounting.json
+++ b/benchmarks/attempt-accounting.json
@@ -649,6 +649,26 @@
         {
           "source": "benchmarks/spontaneous-dispatch/results.json",
           "json_pointer": "/runs/5"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/1"
         }
       ],
       "attempt_pointers": [
@@ -667,11 +687,31 @@
         {
           "source": "benchmarks/spontaneous-dispatch/results.json",
           "json_pointer": "/runs/5"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/1"
         }
       ],
       "count_status": "known",
-      "attempted": 4,
-      "passed": 4,
+      "attempted": 9,
+      "passed": 9,
       "failed": 0
     },
     {
@@ -681,18 +721,42 @@
         {
           "source": "benchmarks/spontaneous-dispatch/results.json",
           "json_pointer": "/runs/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/1"
         }
       ],
       "attempt_pointers": [
         {
           "source": "benchmarks/spontaneous-dispatch/results.json",
           "json_pointer": "/runs/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1"
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/1"
         }
       ],
       "count_status": "known",
-      "attempted": 1,
+      "attempted": 4,
       "passed": 0,
-      "failed": 1
+      "failed": 4
     },
     {
       "id": "cell:benchmarks/spontaneous-dispatch/results.json#not_run",
@@ -730,62 +794,9 @@
         {
           "source": "benchmarks/spontaneous-dispatch/results.json",
           "json_pointer": "/v1_3_7_paired_opt_in_matrix/cue_free/max"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/0"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/1"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/1"
         }
       ],
-      "attempt_pointers": [
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/0"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/tightly_coupled_bug/attempts/1"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/0"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/1"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/0"
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/results.json",
-          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/routine_docs_control/attempts/1"
-        }
-      ],
+      "attempt_pointers": [],
       "count_status": "unknown",
       "attempted": null,
       "passed": null,
@@ -1972,6 +1983,65 @@
           "source": "benchmarks/spontaneous-dispatch/results.json",
           "json_pointer": "/runs/1",
           "raw_stream_sha256": "59e576004c8eae9e2d833307c4785f9b67013bf327f9c0d17b52a6e5a801dd23"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/results.json#/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/results.json",
+        "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0"
+      },
+      "candidate_identity": {
+        "hash": "b26ef4a6a0e02575a39ecc8d3303a8cd7f9e9180548311de399fff527efb3b75",
+        "version": "1.3.7"
+      },
+      "failure_boundary": "topology=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0",
+          "raw_stream_sha256": "567577c4cce8bca9fccf84945c3f2d0cf4f77379cbfbc8e7949a31e0b8524d12"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/results.json#/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/results.json",
+        "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1"
+      },
+      "candidate_identity": {
+        "hash": "b26ef4a6a0e02575a39ecc8d3303a8cd7f9e9180548311de399fff527efb3b75",
+        "version": "1.3.7"
+      },
+      "failure_boundary": "topology=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1",
+          "raw_stream_sha256": "806c11e6564b1f5799a869de6be587603f68e6b91df231b6079da29e71d22171"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/spontaneous-dispatch/results.json#/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/1",
+      "cell_id": "cell:benchmarks/spontaneous-dispatch/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/spontaneous-dispatch/results.json",
+        "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/1"
+      },
+      "candidate_identity": {
+        "hash": "b26ef4a6a0e02575a39ecc8d3303a8cd7f9e9180548311de399fff527efb3b75",
+        "version": "1.3.7"
+      },
+      "failure_boundary": "topology=FAIL",
+      "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/results.json",
+          "json_pointer": "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/1"
         }
       ]
     },

--- a/benchmarks/attempt-accounting.json
+++ b/benchmarks/attempt-accounting.json
@@ -1983,19 +1983,10 @@
         "json_pointer": "/campaign/cells/0"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
       },
       "failure_boundary": "topology_pass=false",
       "evidence": [
-        {
-          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
-          "json_pointer": ""
-        },
-        {
-          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
-          "json_pointer": "/tui_observation",
-          "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad"
-        },
         {
           "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
           "json_pointer": "/campaign/cells/0",
@@ -2011,7 +2002,7 @@
         "json_pointer": "/campaign/cells/1"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
       },
       "failure_boundary": "topology_pass=false",
       "evidence": [
@@ -2030,7 +2021,7 @@
         "json_pointer": "/campaign/cells/2"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
       },
       "failure_boundary": "topology_pass=false",
       "evidence": [
@@ -2049,10 +2040,19 @@
         "json_pointer": "/campaign/cells/3"
       },
       "candidate_identity": {
-        "limitation": "This historical record does not expose a complete version/hash/config identity at the failure pointer."
+        "hash": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
       },
       "failure_boundary": "topology_pass=false",
       "evidence": [
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": ""
+        },
+        {
+          "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+          "json_pointer": "/tui_observation",
+          "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad"
+        },
         {
           "source": "benchmarks/spontaneous-dispatch/cue-free-tui.json",
           "json_pointer": "/campaign/cells/3",

--- a/benchmarks/attempt-accounting.json
+++ b/benchmarks/attempt-accounting.json
@@ -155,6 +155,14 @@
         {
           "source": "benchmarks/baton-compatibility/results.json",
           "json_pointer": "/failed_candidate_gate"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_candidate_gate/turns/1"
         }
       ],
       "attempt_pointers": [
@@ -165,12 +173,20 @@
         {
           "source": "benchmarks/baton-compatibility/results.json",
           "json_pointer": "/failed_candidate_gate/turns/0"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe"
+        },
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_candidate_gate/turns/1"
         }
       ],
       "count_status": "known",
-      "attempted": 2,
+      "attempted": 4,
       "passed": 0,
-      "failed": 2
+      "failed": 4
     },
     {
       "id": "cell:benchmarks/baton-compatibility/results.json#unknown",
@@ -217,10 +233,6 @@
         {
           "source": "benchmarks/baton-compatibility/results.json",
           "json_pointer": "/superseded_candidate_gate/turns/0"
-        },
-        {
-          "source": "benchmarks/baton-compatibility/results.json",
-          "json_pointer": "/superseded_candidate_gate/turns/1"
         }
       ],
       "count_status": "unknown",
@@ -1755,6 +1767,43 @@
           "source": "benchmarks/baton-compatibility/results.json",
           "json_pointer": "/failed_candidate_gate",
           "transcript_sha256": "250b8cd8b53e758299b233d16c2753890a46c6284a99a8d21ba5d5e907bf7ebc"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/baton-compatibility/results.json#/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe",
+      "cell_id": "cell:benchmarks/baton-compatibility/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/baton-compatibility/results.json",
+        "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe"
+      },
+      "candidate_identity": {
+        "limitation": "This historical route probe does not expose a policy version, hash, or configuration identity."
+      },
+      "failure_boundary": "reviewed_failure=EXPLICIT_OPUS_ROUTE_OK",
+      "evidence": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe"
+        }
+      ]
+    },
+    {
+      "id": "failure:benchmarks/baton-compatibility/results.json#/superseded_candidate_gate/turns/1",
+      "cell_id": "cell:benchmarks/baton-compatibility/results.json#failed",
+      "attempt_pointer": {
+        "source": "benchmarks/baton-compatibility/results.json",
+        "json_pointer": "/superseded_candidate_gate/turns/1"
+      },
+      "candidate_identity": {
+        "hash": "dc765dfc22b2c1875101ce665e8b3bba5968ff2549556459e5c2a8c847da0f44",
+        "version": "1.3.0"
+      },
+      "failure_boundary": "is_error=true; disposition=interrupted",
+      "evidence": [
+        {
+          "source": "benchmarks/baton-compatibility/results.json",
+          "json_pointer": "/superseded_candidate_gate/turns/1"
         }
       ]
     },

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -79,6 +79,8 @@ ATTEMPT_ACCOUNTING_PASS_STATUSES = frozenset(
         "passed_activation_dispatch_ownership_collection_final_byte_correctness",
         "passed_before_final_edit",
         "passed_after_final_write",
+        "ready",
+        "confirmed",
     }
 )
 ATTEMPT_ACCOUNTING_FAILURE_STATUSES = frozenset(
@@ -97,6 +99,7 @@ ATTEMPT_ACCOUNTING_FAILURE_STATUSES = frozenset(
         "stopped_after_failed_topology",
         "rejected_quota_exhausted",
         "rejected_operator_contract_blocked_agents",
+        "revise",
     }
 )
 ATTEMPT_ACCOUNTING_NOT_RUN_STATUSES = frozenset(
@@ -132,7 +135,8 @@ ATTEMPT_ACCOUNTING_SINGULAR_ATTEMPTS = {
         "/behavioral_gates/spontaneous_bug_candidate",
         "/behavioral_gates/explicit_lifecycle_turn_1",
         "/behavioral_gates/explicit_lifecycle_user_continuation",
-        "/behavioral_gates/small_lifecycle",
+        "/behavioral_gates/small_lifecycle/turn_1_plan",
+        "/behavioral_gates/small_lifecycle/turn_2_approved_execution",
     ),
     "benchmarks/verifier-boundary/results.json": (
         "/passing_gate/schema_lifecycle/attempt_a",
@@ -669,6 +673,7 @@ def _attempt_accounting_validate(ledger: dict) -> None:
                 expected_state = "unknown"
                 expected_attempted = expected_passed = expected_failed = None
         elif "unknown" in attempt_states:
+            assert set(attempt_states) == {"unknown"}
             expected_state = "unknown"
             expected_attempted = expected_passed = expected_failed = None
         else:
@@ -4533,7 +4538,7 @@ class PolicyContractTests(unittest.TestCase):
             sum(len(cell["claim_pointers"]) for cell in ledger["cells"]), 198
         )
         self.assertEqual(
-            sum(len(cell["attempt_pointers"]) for cell in ledger["cells"]), 138
+            sum(len(cell["attempt_pointers"]) for cell in ledger["cells"]), 139
         )
         self.assertEqual(
             sum(
@@ -4541,7 +4546,7 @@ class PolicyContractTests(unittest.TestCase):
                 for cell in ledger["cells"]
                 if cell["count_status"] == "known"
             ),
-            42,
+            43,
         )
 
         spontaneous_cells = {
@@ -4568,6 +4573,44 @@ class PolicyContractTests(unittest.TestCase):
         self.assertEqual(
             _attempt_accounting_outcome({"topology": "FAIL"}),
             ("failed", ("topology=FAIL",)),
+        )
+
+        prompt_cells = {
+            cell["claim_status"]: cell
+            for cell in ledger["cells"]
+            if cell["id"].startswith(
+                "cell:benchmarks/prompt-compression/results.json#"
+            )
+        }
+        self.assertNotIn("unknown", prompt_cells)
+        self.assertEqual(
+            (
+                prompt_cells["passed"]["attempted"],
+                prompt_cells["passed"]["passed"],
+                prompt_cells["failed"]["attempted"],
+                prompt_cells["failed"]["failed"],
+            ),
+            (3, 3, 4, 4),
+        )
+        self.assertEqual(
+            _attempt_accounting_outcome({"status": "ready"}),
+            ("passed", ("status=ready",)),
+        )
+        self.assertEqual(
+            _attempt_accounting_outcome({"status": "confirmed"}),
+            ("passed", ("status=confirmed",)),
+        )
+        self.assertEqual(
+            _attempt_accounting_outcome({"status": "revise"}),
+            ("failed", ("status=revise",)),
+        )
+        self.assertEqual(
+            sum(
+                len(cell["attempt_pointers"])
+                for cell in ledger["cells"]
+                if cell["count_status"] == "unknown"
+            ),
+            52,
         )
 
         baton_cells = {

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -44,6 +44,7 @@ ATTEMPT_ACCOUNTING_MARKERS = frozenset(
         "status",
         "passed",
         "test_passed",
+        "topology",
         "topology_pass",
         "reachability",
         "raw_stream_sha256",
@@ -178,6 +179,20 @@ ATTEMPT_ACCOUNTING_REVIEWED_IDENTITIES = {
         }
         for index in range(4)
     },
+    **{
+        (
+            "benchmarks/spontaneous-dispatch/results.json",
+            pointer,
+        ): {
+            "hash": "b26ef4a6a0e02575a39ecc8d3303a8cd7f9e9180548311de399fff527efb3b75",
+            "version": "1.3.7",
+        }
+        for pointer in (
+            "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/0",
+            "/v1_3_7_max_prompt_baseline/cells/mechanical/attempts/1",
+            "/v1_3_7_max_prompt_baseline/cells/schema_lifecycle/attempts/1",
+        )
+    },
 }
 ATTEMPT_ACCOUNTING_REVIEWED_EVIDENCE_OWNERS = {
     (
@@ -305,6 +320,8 @@ def _attempt_accounting_outcome(
             boundaries.append(f"{key}=false")
     if record.get("reachability") == "FAIL":
         boundaries.append("reachability=FAIL")
+    if record.get("topology") == "FAIL":
+        boundaries.append("topology=FAIL")
     status = record.get("status")
     if status in ATTEMPT_ACCOUNTING_FAILURE_STATUSES:
         boundaries.append(f"status={status}")
@@ -318,6 +335,8 @@ def _attempt_accounting_outcome(
             return "passed", (f"{key}=true",)
     if record.get("reachability") == "PASS":
         return "passed", ("reachability=PASS",)
+    if record.get("topology") == "PASS":
+        return "passed", ("topology=PASS",)
     if status in ATTEMPT_ACCOUNTING_PASS_STATUSES:
         return "passed", (f"status={status}",)
     if status in ATTEMPT_ACCOUNTING_NOT_RUN_STATUSES:
@@ -4477,7 +4496,7 @@ class PolicyContractTests(unittest.TestCase):
 
         self.assertEqual(len(ledger["sources"]), 11)
         self.assertEqual(
-            sum(len(cell["claim_pointers"]) for cell in ledger["cells"]), 193
+            sum(len(cell["claim_pointers"]) for cell in ledger["cells"]), 196
         )
         self.assertEqual(
             sum(len(cell["attempt_pointers"]) for cell in ledger["cells"]), 137
@@ -4488,7 +4507,33 @@ class PolicyContractTests(unittest.TestCase):
                 for cell in ledger["cells"]
                 if cell["count_status"] == "known"
             ),
-            37,
+            40,
+        )
+
+        spontaneous_cells = {
+            cell["claim_status"]: cell
+            for cell in ledger["cells"]
+            if cell["id"].startswith(
+                "cell:benchmarks/spontaneous-dispatch/results.json#"
+            )
+        }
+        self.assertEqual(
+            (
+                spontaneous_cells["passed"]["attempted"],
+                spontaneous_cells["passed"]["passed"],
+                spontaneous_cells["failed"]["attempted"],
+                spontaneous_cells["failed"]["failed"],
+            ),
+            (9, 9, 4, 4),
+        )
+        self.assertEqual(spontaneous_cells["unknown"]["attempt_pointers"], [])
+        self.assertEqual(
+            _attempt_accounting_outcome({"topology": "PASS"}),
+            ("passed", ("topology=PASS",)),
+        )
+        self.assertEqual(
+            _attempt_accounting_outcome({"topology": "FAIL"}),
+            ("failed", ("topology=FAIL",)),
         )
 
         verifier_failed = next(

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from copy import deepcopy
 from decimal import Decimal
 import hashlib
 import json
@@ -23,6 +24,571 @@ ROLES = (
     "verifier",
     "security-executor",
 )
+
+ATTEMPT_ACCOUNTING_SOURCES = (
+    "benchmarks/baton-compatibility/results.json",
+    "benchmarks/baton-dispatch-effect/results.json",
+    "benchmarks/dispatch-brake/results.json",
+    "benchmarks/dispatch-brake/positive-controls/results.json",
+    "benchmarks/prompt-compression/results.json",
+    "benchmarks/spontaneous-dispatch/results.json",
+    "benchmarks/spontaneous-dispatch/compact-policy-full-matrix.json",
+    "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+    "benchmarks/spontaneous-dispatch/issue-29-recovery.json",
+    "benchmarks/spontaneous-dispatch/issue-29-topology.json",
+    "benchmarks/verifier-boundary/results.json",
+)
+ATTEMPT_ACCOUNTING_MARKERS = frozenset(
+    {
+        "claim",
+        "status",
+        "passed",
+        "test_passed",
+        "topology_pass",
+        "reachability",
+        "raw_stream_sha256",
+        "transcript_sha256",
+    }
+)
+ATTEMPT_ACCOUNTING_COVERAGE_EXCLUSIONS = {
+    (
+        "benchmarks/prompt-compression/results.json",
+        "/static_gate",
+    ): "static byte/policy gate, not a behavioral invocation",
+    (
+        "benchmarks/prompt-compression/results.json",
+        "/context_census",
+    ): "static context census, not a behavioral invocation",
+    (
+        "benchmarks/prompt-compression/results.json",
+        "/paid_campaign",
+    ): "campaign bookkeeping, not a behavioral invocation",
+}
+ATTEMPT_ACCOUNTING_PASS_STATUSES = frozenset(
+    {
+        "passed",
+        "passed_with_corrective_verification",
+        "success",
+        "release_qualified",
+        "correctness_pass",
+        "correctness_pass_no_activation",
+        "no_activation_observed_for_bounded_task",
+        "passed_activation_dispatch_ownership_collection_correctness",
+        "passed_activation_dispatch_ownership_collection_final_byte_correctness",
+        "passed_before_final_edit",
+        "passed_after_final_write",
+    }
+)
+ATTEMPT_ACCOUNTING_FAILURE_STATUSES = frozenset(
+    {
+        "rejected",
+        "failed",
+        "error_max_budget_usd",
+        "error_during_execution",
+        "success_topology_fail",
+        "activation_dispatch_pass_ownership_fail",
+        "activation_dispatch_parallel_launch_pass_ownership_fail",
+        "topology_pass_runtime_limit_outcome_incomplete",
+        "correctness_passed_topology_blocked",
+        "correctness_passed_same_topology_blocker",
+        "stopped_after_two_revise",
+        "stopped_after_failed_topology",
+        "rejected_quota_exhausted",
+        "rejected_operator_contract_blocked_agents",
+    }
+)
+ATTEMPT_ACCOUNTING_NOT_RUN_STATUSES = frozenset(
+    {"not_run", "usage_credits_required"}
+)
+ATTEMPT_ACCOUNTING_FAILURE_FIELDS = (
+    "failure",
+    "failures",
+    "failure_reason",
+    "failure_reasons",
+    "failure_summary",
+)
+ATTEMPT_ACCOUNTING_ATTEMPT_ARRAY_KEYS = frozenset(
+    {
+        "runs",
+        "attempts",
+        "cells",
+        "complete_runs",
+        "interrupted_policy_probes",
+        "failed_attempts",
+    }
+)
+ATTEMPT_ACCOUNTING_SINGULAR_ATTEMPTS = {
+    "benchmarks/baton-dispatch-effect/results.json": (
+        "/release_payload_replay",
+    ),
+    "benchmarks/prompt-compression/results.json": (
+        "/behavioral_gates/spontaneous_mechanical_candidate",
+        "/behavioral_gates/spontaneous_mechanical_v1_3_3_control",
+        "/behavioral_gates/spontaneous_bug_candidate",
+        "/behavioral_gates/explicit_lifecycle_turn_1",
+        "/behavioral_gates/explicit_lifecycle_user_continuation",
+        "/behavioral_gates/small_lifecycle",
+    ),
+    "benchmarks/verifier-boundary/results.json": (
+        "/passing_gate/schema_lifecycle/attempt_a",
+        "/passing_gate/schema_lifecycle/attempt_b",
+        "/passing_gate/routine_docs_control",
+        "/passing_gate/post_cap_plan_control",
+        "/superseded_v1_3_6_passing_gate/schema_lifecycle",
+        "/superseded_v1_3_6_passing_gate/routine_docs_control",
+        "/superseded_v1_3_6_passing_gate/post_cap_plan_control",
+    ),
+}
+ATTEMPT_ACCOUNTING_REVIEWED_FAILURES = {
+    (
+        "benchmarks/verifier-boundary/results.json",
+        "/failed_attempts/2",
+    ): {
+        "name": "compressed-candidate-schema-non-reproduction",
+        "outcome": "did not reproduce",
+    },
+    (
+        "benchmarks/verifier-boundary/results.json",
+        "/failed_attempts/3",
+    ): {
+        "name": "uncollected-background-verification",
+        "outcome": "approval gate held; acceptance not met",
+    },
+}
+
+
+def _attempt_accounting_pointer_part(value: object) -> str:
+    return str(value).replace("~", "~0").replace("/", "~1")
+
+
+def _attempt_accounting_marked_records(
+    value: object, pointer: str = ""
+) -> list[tuple[str, dict]]:
+    records: list[tuple[str, dict]] = []
+    if isinstance(value, dict):
+        if ATTEMPT_ACCOUNTING_MARKERS.intersection(value):
+            records.append((pointer, value))
+        for key, child in value.items():
+            records.extend(
+                _attempt_accounting_marked_records(
+                    child, pointer + "/" + _attempt_accounting_pointer_part(key)
+                )
+            )
+    elif isinstance(value, list):
+        for index, child in enumerate(value):
+            records.extend(
+                _attempt_accounting_marked_records(child, pointer + "/" + str(index))
+            )
+    return records
+
+
+def _attempt_accounting_nonempty(value: object) -> bool:
+    return value not in (None, "", [], {})
+
+
+def _attempt_accounting_outcome(
+    record: dict, source: str | None = None, pointer: str | None = None
+) -> tuple[str, tuple[str, ...]]:
+    if source is not None and pointer is not None:
+        reviewed_failure = ATTEMPT_ACCOUNTING_REVIEWED_FAILURES.get(
+            (source, pointer)
+        )
+        if reviewed_failure is not None and all(
+            record.get(field) == expected
+            for field, expected in reviewed_failure.items()
+        ):
+            return "failed", (f"reviewed_failure={reviewed_failure['name']}",)
+
+    boundaries: list[str] = []
+    for key in ("passed", "test_passed", "topology_pass"):
+        if record.get(key) is False:
+            boundaries.append(f"{key}=false")
+    if record.get("reachability") == "FAIL":
+        boundaries.append("reachability=FAIL")
+    status = record.get("status")
+    if status in ATTEMPT_ACCOUNTING_FAILURE_STATUSES:
+        boundaries.append(f"status={status}")
+    for key in ATTEMPT_ACCOUNTING_FAILURE_FIELDS:
+        if key in record and _attempt_accounting_nonempty(record[key]):
+            boundaries.append(f"{key}=nonempty")
+    if boundaries:
+        return "failed", tuple(boundaries)
+    for key in ("passed", "test_passed", "topology_pass"):
+        if record.get(key) is True:
+            return "passed", (f"{key}=true",)
+    if record.get("reachability") == "PASS":
+        return "passed", ("reachability=PASS",)
+    if status in ATTEMPT_ACCOUNTING_PASS_STATUSES:
+        return "passed", (f"status={status}",)
+    if status in ATTEMPT_ACCOUNTING_NOT_RUN_STATUSES:
+        return "not_run", (f"status={status}",)
+    return "unknown", ()
+
+
+def _attempt_accounting_attempt_pointers(
+    source: str, document: object
+) -> list[str]:
+    pointers: list[str] = []
+
+    def add(pointer: str) -> None:
+        if pointer not in pointers:
+            pointers.append(pointer)
+
+    def walk(value: object, pointer: str = "") -> None:
+        if isinstance(value, dict):
+            for key, child in value.items():
+                child_pointer = pointer + "/" + _attempt_accounting_pointer_part(key)
+                if key in ATTEMPT_ACCOUNTING_ATTEMPT_ARRAY_KEYS and isinstance(
+                    child, list
+                ):
+                    for index in range(len(child)):
+                        add(child_pointer + "/" + str(index))
+                walk(child, child_pointer)
+        elif isinstance(value, list):
+            for index, child in enumerate(value):
+                walk(child, pointer + "/" + str(index))
+
+    walk(document)
+    if source == "benchmarks/baton-compatibility/results.json":
+        for pointer, record in _attempt_accounting_marked_records(document):
+            if record.get("granularity") != "invocation":
+                continue
+            turns = record.get("turns")
+            if isinstance(turns, list):
+                for index in range(len(turns)):
+                    add(pointer + "/turns/" + str(index))
+            else:
+                add(pointer)
+    for pointer in ATTEMPT_ACCOUNTING_SINGULAR_ATTEMPTS.get(source, ()):
+        add(pointer)
+    return pointers
+
+
+def _attempt_accounting_attempt_outcome(
+    source: str, pointer: str, record: dict, document: object
+) -> tuple[str, tuple[str, ...]]:
+    outcome = _attempt_accounting_outcome(record, source, pointer)
+    if outcome[0] != "unknown":
+        return outcome
+    if (
+        source == "benchmarks/baton-compatibility/results.json"
+        and pointer.startswith("/failed_candidate_gate/turns/")
+    ):
+        parent = _attempt_accounting_resolve_pointer(
+            document, "/failed_candidate_gate"
+        )
+        parent_outcome = _attempt_accounting_outcome(
+            parent,
+            source,
+            "/failed_candidate_gate",
+        )
+        if parent_outcome[0] == "failed":
+            return parent_outcome
+    return outcome
+
+
+def _attempt_accounting_discover_public_json() -> tuple[str, ...]:
+    excluded_names = {
+        "agent-calls",
+        "agent-calls.json",
+        "traces",
+        "traces.json",
+        "budget",
+        "budget.json",
+        "package",
+        "package.json",
+        "agents",
+        "agents.json",
+        "settings.snippet",
+        "settings.snippet.json",
+    }
+    found: list[str] = []
+    for path in sorted((ROOT / "benchmarks").rglob("*.json")):
+        relative = path.relative_to(ROOT).as_posix()
+        parts = relative.split("/")
+        if relative == "benchmarks/attempt-accounting.json":
+            continue
+        if any(part in excluded_names for part in parts):
+            continue
+        if any(part == "fixture" or "snapshot" in part for part in parts):
+            continue
+        found.append(relative)
+    return tuple(found)
+
+
+def _attempt_accounting_resolve_pointer(document: object, pointer: str) -> object:
+    if pointer == "":
+        return document
+    if not pointer.startswith("/"):
+        raise AssertionError(f"invalid JSON Pointer: {pointer!r}")
+    value = document
+    for token in pointer[1:].split("/"):
+        token = token.replace("~1", "/").replace("~0", "~")
+        if isinstance(value, list):
+            if token == "0":
+                index = 0
+            else:
+                try:
+                    index = int(token)
+                except ValueError as error:
+                    raise AssertionError(
+                        f"non-index token {token!r} for list pointer {pointer!r}"
+                    ) from error
+            if index < 0 or index >= len(value):
+                raise AssertionError(f"missing list pointer {pointer!r}")
+            value = value[index]
+        elif isinstance(value, dict) and token in value:
+            value = value[token]
+        else:
+            raise AssertionError(f"missing JSON Pointer {pointer!r}")
+    return value
+
+
+def _attempt_accounting_validate(ledger: dict) -> None:
+    assert isinstance(ledger, dict)
+    assert ledger.get("schema_version") == 1
+    source_entries = ledger.get("sources")
+    assert isinstance(source_entries, list)
+    source_paths = [entry.get("path") for entry in source_entries]
+    assert source_paths == list(ATTEMPT_ACCOUNTING_SOURCES)
+    assert len(source_paths) == len(set(source_paths))
+    discovered_sources = _attempt_accounting_discover_public_json()
+    assert len(discovered_sources) == len(set(discovered_sources))
+    assert set(discovered_sources) == set(ATTEMPT_ACCOUNTING_SOURCES)
+
+    for entry, source in zip(source_entries, ATTEMPT_ACCOUNTING_SOURCES):
+        assert isinstance(entry, dict)
+        assert entry.get("path") == source
+        digest = entry.get("sha256")
+        assert isinstance(digest, str)
+        assert re.fullmatch(r"[0-9a-f]{64}", digest)
+        assert digest == hashlib.sha256((ROOT / source).read_bytes()).hexdigest()
+
+    exclusions = ledger.get("coverage_exclusions")
+    assert isinstance(exclusions, list)
+    actual_exclusions = {}
+    for exclusion in exclusions:
+        assert isinstance(exclusion, dict)
+        key = (exclusion.get("source"), exclusion.get("json_pointer"))
+        assert key not in actual_exclusions
+        reason = exclusion.get("reason")
+        assert isinstance(reason, str) and reason
+        actual_exclusions[key] = reason
+    assert actual_exclusions == ATTEMPT_ACCOUNTING_COVERAGE_EXCLUSIONS
+
+    documents = {
+        source: json.loads((ROOT / source).read_text(encoding="utf-8"))
+        for source in ATTEMPT_ACCOUNTING_SOURCES
+    }
+    oracle = {}
+    outcomes = {}
+    for source, document in documents.items():
+        for pointer, record in _attempt_accounting_marked_records(document):
+            key = (source, pointer)
+            if key in ATTEMPT_ACCOUNTING_COVERAGE_EXCLUSIONS:
+                continue
+            oracle[key] = record
+            outcomes[key] = _attempt_accounting_outcome(record, source, pointer)
+
+    attempt_oracle = {}
+    attempt_outcomes = {}
+    attempt_order = []
+    for source, document in documents.items():
+        for pointer in _attempt_accounting_attempt_pointers(source, document):
+            key = (source, pointer)
+            assert key not in attempt_oracle
+            record = _attempt_accounting_resolve_pointer(document, pointer)
+            assert isinstance(record, dict)
+            attempt_oracle[key] = record
+            attempt_outcomes[key] = _attempt_accounting_attempt_outcome(
+                source, pointer, record, document
+            )
+            attempt_order.append(key)
+    assert attempt_order
+
+    cells = ledger.get("cells")
+    assert isinstance(cells, list) and cells
+    cell_by_id = {}
+    owner_by_pointer = {}
+    for cell in cells:
+        assert isinstance(cell, dict)
+        cell_id = cell.get("id")
+        assert isinstance(cell_id, str) and cell_id
+        assert cell_id not in cell_by_id
+        cell_by_id[cell_id] = cell
+        pointers = cell.get("claim_pointers")
+        assert isinstance(pointers, list) and pointers
+        for claim_pointer in pointers:
+            assert isinstance(claim_pointer, dict)
+            source = claim_pointer.get("source")
+            pointer = claim_pointer.get("json_pointer")
+            key = (source, pointer)
+            assert key in oracle
+            assert key not in owner_by_pointer
+            assert isinstance(
+                _attempt_accounting_resolve_pointer(documents[source], pointer), dict
+            )
+            owner_by_pointer[key] = cell_id
+    assert set(owner_by_pointer) == set(oracle)
+    assert {source for source, _ in owner_by_pointer} == set(
+        ATTEMPT_ACCOUNTING_SOURCES
+    )
+
+    attempt_owner_by_pointer = {}
+    for cell in cells:
+        attempt_pointers = cell.get("attempt_pointers")
+        assert isinstance(attempt_pointers, list)
+        for attempt_pointer in attempt_pointers:
+            assert isinstance(attempt_pointer, dict)
+            source = attempt_pointer.get("source")
+            pointer = attempt_pointer.get("json_pointer")
+            key = (source, pointer)
+            assert key in attempt_oracle
+            assert key not in attempt_owner_by_pointer
+            attempt_owner_by_pointer[key] = cell["id"]
+    assert set(attempt_owner_by_pointer) == set(attempt_oracle)
+
+    failure_oracle = {}
+    for key, (state, boundaries) in outcomes.items():
+        if state == "failed":
+            failure_oracle[key] = boundaries
+    for key, reviewed_failure in ATTEMPT_ACCOUNTING_REVIEWED_FAILURES.items():
+        assert key in attempt_oracle
+        source, pointer = key
+        record = attempt_oracle[key]
+        assert all(
+            record.get(field) == expected
+            for field, expected in reviewed_failure.items()
+        )
+        failure_oracle[key] = (
+            f"reviewed_failure={reviewed_failure['name']}",
+        )
+    attempt_failure_oracle = {
+        key: boundaries
+        for key, (state, boundaries) in attempt_outcomes.items()
+        if state == "failed"
+    }
+
+    owned_failures = {cell_id: 0 for cell_id in cell_by_id}
+    for cell in cells:
+        cell_id = cell["id"]
+        claim_pointers = [
+            (claim_pointer["source"], claim_pointer["json_pointer"])
+            for claim_pointer in cell["claim_pointers"]
+        ]
+        claim_states = {outcomes[key][0] for key in claim_pointers}
+        assert len(claim_states) == 1
+        assert cell.get("claim_status") == next(iter(claim_states))
+
+        attempt_pointers = [
+            (attempt_pointer["source"], attempt_pointer["json_pointer"])
+            for attempt_pointer in cell["attempt_pointers"]
+        ]
+        attempt_states = [attempt_outcomes[key][0] for key in attempt_pointers]
+        if not attempt_pointers:
+            if next(iter(claim_states)) == "not_run":
+                expected_state = "known"
+                expected_attempted = expected_passed = expected_failed = 0
+            else:
+                expected_state = "unknown"
+                expected_attempted = expected_passed = expected_failed = None
+        elif "unknown" in attempt_states:
+            expected_state = "unknown"
+            expected_attempted = expected_passed = expected_failed = None
+        else:
+            expected_state = "known"
+            expected_attempted = sum(
+                state in ("passed", "failed") for state in attempt_states
+            )
+            expected_passed = attempt_states.count("passed")
+            expected_failed = attempt_states.count("failed")
+            if all(state == "not_run" for state in attempt_states):
+                expected_attempted = expected_passed = expected_failed = 0
+
+        assert cell.get("count_status") == expected_state
+        if expected_state == "unknown":
+            assert cell.get("attempted") is None
+            assert cell.get("passed") is None
+            assert cell.get("failed") is None
+            reason = cell.get("reason")
+            assert isinstance(reason, str) and reason
+        else:
+            for field, expected in (
+                ("attempted", expected_attempted),
+                ("passed", expected_passed),
+                ("failed", expected_failed),
+            ):
+                value = cell.get(field)
+                assert type(value) is int and value >= 0
+                assert value == expected
+            assert cell["attempted"] == cell["passed"] + cell["failed"]
+            if expected_attempted == 0:
+                reason = cell.get("reason")
+                assert isinstance(reason, str) and reason
+        for key in attempt_pointers:
+            if key in attempt_failure_oracle:
+                owned_failures[cell_id] += 1
+
+    failure_entries = ledger.get("failed_attempts")
+    assert isinstance(failure_entries, list)
+    failure_ids = set()
+    attempt_failures_by_pointer = {}
+    evidence_by_pointer = {}
+    for entry in failure_entries:
+        assert isinstance(entry, dict)
+        failure_id = entry.get("id")
+        assert (
+            isinstance(failure_id, str)
+            and failure_id
+            and failure_id not in failure_ids
+        )
+        failure_ids.add(failure_id)
+        cell_id = entry.get("cell_id")
+        assert cell_id in cell_by_id
+        attempt_pointer = entry.get("attempt_pointer")
+        assert isinstance(attempt_pointer, dict)
+        attempt_key = (
+            attempt_pointer.get("source"),
+            attempt_pointer.get("json_pointer"),
+        )
+        assert attempt_key in attempt_failure_oracle
+        assert attempt_key not in attempt_failures_by_pointer
+        assert attempt_owner_by_pointer[attempt_key] == cell_id
+        identity = entry.get("candidate_identity")
+        assert isinstance(identity, dict)
+        assert any(
+            key in identity and _attempt_accounting_nonempty(identity[key])
+            for key in ("version", "hash", "config", "limitation")
+        )
+        boundary = entry.get("failure_boundary")
+        assert isinstance(boundary, str) and boundary
+        evidence = entry.get("evidence")
+        assert isinstance(evidence, list) and evidence
+        assert boundary == "; ".join(attempt_failure_oracle[attempt_key])
+        for evidence_item in evidence:
+            assert isinstance(evidence_item, dict)
+            key = (
+                evidence_item.get("source"),
+                evidence_item.get("json_pointer"),
+            )
+            assert key in failure_oracle
+            assert key not in evidence_by_pointer
+            owner = owner_by_pointer.get(key, attempt_owner_by_pointer.get(key))
+            assert owner == cell_id
+            record = oracle.get(key, attempt_oracle.get(key))
+            assert isinstance(record, dict)
+            for hash_key in ("raw_stream_sha256", "transcript_sha256"):
+                if isinstance(record.get(hash_key), str):
+                    assert evidence_item.get(hash_key) == record[hash_key]
+            evidence_by_pointer[key] = entry
+        attempt_failures_by_pointer[attempt_key] = entry
+
+    assert set(attempt_failures_by_pointer) == set(attempt_failure_oracle)
+    assert set(evidence_by_pointer) == set(failure_oracle)
+    for cell_id, count in owned_failures.items():
+        assert count == sum(
+            entry.get("cell_id") == cell_id for entry in failure_entries
+        )
 
 
 class PolicyContractTests(unittest.TestCase):
@@ -3770,6 +4336,36 @@ class PolicyContractTests(unittest.TestCase):
                 )
             )
         self.assertNotIn("interrupted_invocation", json.dumps(results, default=str))
+
+    def test_attempt_accounting_ledger_is_complete_and_tamper_evident(self) -> None:
+        ledger_path = ROOT / "benchmarks" / "attempt-accounting.json"
+        ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
+        _attempt_accounting_validate(ledger)
+
+        missing_cell_mapping = deepcopy(ledger)
+        cell = next(
+            cell
+            for cell in missing_cell_mapping["cells"]
+            if len(cell["claim_pointers"]) > 1
+        )
+        cell["claim_pointers"].pop()
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(missing_cell_mapping)
+
+        missing_attempt_mapping = deepcopy(ledger)
+        attempt_cell = next(
+            cell
+            for cell in missing_attempt_mapping["cells"]
+            if cell["attempt_pointers"]
+        )
+        attempt_cell["attempt_pointers"].pop()
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(missing_attempt_mapping)
+
+        missing_failure_mapping = deepcopy(ledger)
+        missing_failure_mapping["failed_attempts"].pop()
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(missing_failure_mapping)
 
 
 if __name__ == "__main__":

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -169,6 +169,35 @@ ATTEMPT_ACCOUNTING_REVIEWED_IDENTITIES = {
         "benchmarks/prompt-compression/results.json",
         "/behavioral_gates/spontaneous_mechanical_v1_3_3_control",
     ): {"version": "1.3.3"},
+    **{
+        (
+            "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+            f"/campaign/cells/{index}",
+        ): {
+            "hash": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
+        }
+        for index in range(4)
+    },
+}
+ATTEMPT_ACCOUNTING_REVIEWED_EVIDENCE_OWNERS = {
+    (
+        "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+        "",
+        0,
+    ): (
+        "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+        "/campaign/cells/3",
+        0,
+    ),
+    (
+        "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+        "/tui_observation",
+        0,
+    ): (
+        "benchmarks/spontaneous-dispatch/cue-free-tui.json",
+        "/campaign/cells/3",
+        0,
+    ),
 }
 
 
@@ -669,6 +698,9 @@ def _attempt_accounting_validate(ledger: dict) -> None:
             key = _attempt_accounting_pointer_key(evidence_item)
             assert key in failure_oracle
             assert key not in evidence_by_pointer
+            reviewed_owner = ATTEMPT_ACCOUNTING_REVIEWED_EVIDENCE_OWNERS.get(key)
+            if reviewed_owner is not None:
+                assert attempt_key == reviewed_owner
             claim_key = (key[0], key[1])
             owner = owner_by_pointer.get(claim_key, attempt_owner_by_pointer.get(key))
             assert owner == cell_id
@@ -4552,6 +4584,65 @@ class PolicyContractTests(unittest.TestCase):
         }
         with self.assertRaises(AssertionError):
             _attempt_accounting_validate(control_limitation)
+
+        cue_free_failures = [
+            entry
+            for entry in ledger["failed_attempts"]
+            if entry["attempt_pointer"]["source"]
+            == "benchmarks/spontaneous-dispatch/cue-free-tui.json"
+        ]
+        self.assertEqual(len(cue_free_failures), 4)
+        self.assertTrue(
+            all(
+                entry["candidate_identity"]
+                == {
+                    "hash": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
+                }
+                for entry in cue_free_failures
+            )
+        )
+        cue_free_identity = deepcopy(ledger)
+        cue_free_entry = next(
+            entry
+            for entry in cue_free_identity["failed_attempts"]
+            if entry["attempt_pointer"]["source"]
+            == "benchmarks/spontaneous-dispatch/cue-free-tui.json"
+        )
+        cue_free_entry["candidate_identity"] = {
+            "limitation": "identity intentionally removed"
+        }
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(cue_free_identity)
+
+        tui_entry = next(
+            entry
+            for entry in cue_free_failures
+            if entry["attempt_pointer"]["json_pointer"] == "/campaign/cells/3"
+        )
+        self.assertEqual(
+            [item["json_pointer"] for item in tui_entry["evidence"]],
+            ["", "/tui_observation", "/campaign/cells/3"],
+        )
+        wrong_tui_owner = deepcopy(ledger)
+        wrong_tui_failures = [
+            entry
+            for entry in wrong_tui_owner["failed_attempts"]
+            if entry["attempt_pointer"]["source"]
+            == "benchmarks/spontaneous-dispatch/cue-free-tui.json"
+        ]
+        wrong_cell_zero = next(
+            entry
+            for entry in wrong_tui_failures
+            if entry["attempt_pointer"]["json_pointer"] == "/campaign/cells/0"
+        )
+        wrong_cell_three = next(
+            entry
+            for entry in wrong_tui_failures
+            if entry["attempt_pointer"]["json_pointer"] == "/campaign/cells/3"
+        )
+        wrong_cell_zero["evidence"].append(wrong_cell_three["evidence"].pop(1))
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(wrong_tui_owner)
 
         missing_cell_mapping = deepcopy(ledger)
         cell = next(

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -155,6 +155,21 @@ ATTEMPT_ACCOUNTING_REVIEWED_FAILURES = {
         "outcome": "approval gate held; acceptance not met",
     },
 }
+ATTEMPT_ACCOUNTING_IDENTITY_FIELDS = (
+    ("policy_sha256", "hash"),
+    ("policy_orchestration_sha256", "hash"),
+    ("orchestration_sha256", "hash"),
+    ("configuration", "config"),
+    ("policy_version", "version"),
+    ("candidate_version", "version"),
+    ("release_candidate_version", "version"),
+)
+ATTEMPT_ACCOUNTING_REVIEWED_IDENTITIES = {
+    (
+        "benchmarks/prompt-compression/results.json",
+        "/behavioral_gates/spontaneous_mechanical_v1_3_3_control",
+    ): {"version": "1.3.3"},
+}
 
 
 def _attempt_accounting_pointer_part(value: object) -> str:
@@ -184,6 +199,62 @@ def _attempt_accounting_marked_records(
 
 def _attempt_accounting_nonempty(value: object) -> bool:
     return value not in (None, "", [], {})
+
+
+def _attempt_accounting_pointer_key(pointer: dict) -> tuple[str, str, int]:
+    assert isinstance(pointer, dict)
+    source = pointer.get("source")
+    json_pointer = pointer.get("json_pointer")
+    occurrence = pointer.get("occurrence", 0)
+    assert isinstance(source, str) and source
+    assert isinstance(json_pointer, str)
+    assert type(occurrence) is int and occurrence >= 0
+    return source, json_pointer, occurrence
+
+
+def _attempt_accounting_occurrence_count(
+    source: str, pointer: str, record: dict
+) -> int:
+    if source != "benchmarks/verifier-boundary/results.json":
+        return 1
+    if pointer == "/failed_attempts/2":
+        return 2 if isinstance(record.get("inconclusive_diagnostic"), dict) else 1
+    if pointer == "/failed_attempts/3":
+        hashes = record.get("raw_stream_sha256")
+        return len(hashes) if isinstance(hashes, list) and hashes else 1
+    return 1
+
+
+def _attempt_accounting_candidate_identity(
+    record: dict,
+) -> dict[str, object]:
+    identity: dict[str, object] = {}
+    for source_key, identity_key in ATTEMPT_ACCOUNTING_IDENTITY_FIELDS:
+        value = record.get(source_key)
+        if identity_key not in identity and _attempt_accounting_nonempty(value):
+            identity[identity_key] = value
+    return identity
+
+
+def _attempt_accounting_candidate_identity_for_attempt(
+    source: str, pointer: str, document: object
+) -> dict[str, object]:
+    reviewed_identity = ATTEMPT_ACCOUNTING_REVIEWED_IDENTITIES.get(
+        (source, pointer)
+    )
+    if reviewed_identity is not None:
+        return reviewed_identity
+    if pointer != "" and not pointer.startswith("/"):
+        raise AssertionError(f"invalid JSON Pointer: {pointer!r}")
+    tokens = pointer[1:].split("/") if pointer else []
+    for depth in range(len(tokens), -1, -1):
+        ancestor_pointer = "" if depth == 0 else "/" + "/".join(tokens[:depth])
+        ancestor = _attempt_accounting_resolve_pointer(document, ancestor_pointer)
+        if isinstance(ancestor, dict):
+            identity = _attempt_accounting_candidate_identity(ancestor)
+            if identity:
+                return identity
+    return {}
 
 
 def _attempt_accounting_outcome(
@@ -227,12 +298,21 @@ def _attempt_accounting_outcome(
 
 def _attempt_accounting_attempt_pointers(
     source: str, document: object
-) -> list[str]:
-    pointers: list[str] = []
+) -> list[tuple[str, int]]:
+    pointers: list[tuple[str, int]] = []
 
-    def add(pointer: str) -> None:
-        if pointer not in pointers:
-            pointers.append(pointer)
+    def add(pointer: str, occurrence: int = 0) -> None:
+        key = (pointer, occurrence)
+        if key not in pointers:
+            pointers.append(key)
+
+    def add_attempt(pointer: str) -> None:
+        record = _attempt_accounting_resolve_pointer(document, pointer)
+        assert isinstance(record, dict)
+        for occurrence in range(
+            _attempt_accounting_occurrence_count(source, pointer, record)
+        ):
+            add(pointer, occurrence)
 
     def walk(value: object, pointer: str = "") -> None:
         if isinstance(value, dict):
@@ -242,7 +322,7 @@ def _attempt_accounting_attempt_pointers(
                     child, list
                 ):
                     for index in range(len(child)):
-                        add(child_pointer + "/" + str(index))
+                        add_attempt(child_pointer + "/" + str(index))
                 walk(child, child_pointer)
         elif isinstance(value, list):
             for index, child in enumerate(value):
@@ -256,17 +336,29 @@ def _attempt_accounting_attempt_pointers(
             turns = record.get("turns")
             if isinstance(turns, list):
                 for index in range(len(turns)):
-                    add(pointer + "/turns/" + str(index))
+                    add_attempt(pointer + "/turns/" + str(index))
             else:
-                add(pointer)
+                add_attempt(pointer)
     for pointer in ATTEMPT_ACCOUNTING_SINGULAR_ATTEMPTS.get(source, ()):
-        add(pointer)
+        add_attempt(pointer)
     return pointers
 
 
 def _attempt_accounting_attempt_outcome(
-    source: str, pointer: str, record: dict, document: object
+    source: str,
+    pointer: str,
+    occurrence: int,
+    record: dict,
+    document: object,
 ) -> tuple[str, tuple[str, ...]]:
+    if (
+        source == "benchmarks/verifier-boundary/results.json"
+        and pointer == "/failed_attempts/2"
+        and occurrence == 1
+    ):
+        diagnostic = record.get("inconclusive_diagnostic")
+        if isinstance(diagnostic, dict):
+            return "failed", ("inconclusive_diagnostic=nonempty",)
     outcome = _attempt_accounting_outcome(record, source, pointer)
     if outcome[0] != "unknown":
         return outcome
@@ -394,14 +486,16 @@ def _attempt_accounting_validate(ledger: dict) -> None:
     attempt_outcomes = {}
     attempt_order = []
     for source, document in documents.items():
-        for pointer in _attempt_accounting_attempt_pointers(source, document):
-            key = (source, pointer)
+        for pointer, occurrence in _attempt_accounting_attempt_pointers(
+            source, document
+        ):
+            key = (source, pointer, occurrence)
             assert key not in attempt_oracle
             record = _attempt_accounting_resolve_pointer(document, pointer)
             assert isinstance(record, dict)
             attempt_oracle[key] = record
             attempt_outcomes[key] = _attempt_accounting_attempt_outcome(
-                source, pointer, record, document
+                source, pointer, occurrence, record, document
             )
             attempt_order.append(key)
     assert attempt_order
@@ -439,10 +533,7 @@ def _attempt_accounting_validate(ledger: dict) -> None:
         attempt_pointers = cell.get("attempt_pointers")
         assert isinstance(attempt_pointers, list)
         for attempt_pointer in attempt_pointers:
-            assert isinstance(attempt_pointer, dict)
-            source = attempt_pointer.get("source")
-            pointer = attempt_pointer.get("json_pointer")
-            key = (source, pointer)
+            key = _attempt_accounting_pointer_key(attempt_pointer)
             assert key in attempt_oracle
             assert key not in attempt_owner_by_pointer
             attempt_owner_by_pointer[key] = cell["id"]
@@ -451,18 +542,21 @@ def _attempt_accounting_validate(ledger: dict) -> None:
     failure_oracle = {}
     for key, (state, boundaries) in outcomes.items():
         if state == "failed":
-            failure_oracle[key] = boundaries
+            failure_oracle[(*key, 0)] = boundaries
     for key, reviewed_failure in ATTEMPT_ACCOUNTING_REVIEWED_FAILURES.items():
-        assert key in attempt_oracle
         source, pointer = key
-        record = attempt_oracle[key]
+        record = _attempt_accounting_resolve_pointer(documents[source], pointer)
+        assert isinstance(record, dict)
         assert all(
             record.get(field) == expected
             for field, expected in reviewed_failure.items()
         )
-        failure_oracle[key] = (
-            f"reviewed_failure={reviewed_failure['name']}",
-        )
+        boundary = (f"reviewed_failure={reviewed_failure['name']}",)
+        for occurrence in range(
+            _attempt_accounting_occurrence_count(source, pointer, record)
+        ):
+            assert (source, pointer, occurrence) in attempt_oracle
+            failure_oracle[(source, pointer, occurrence)] = boundary
     attempt_failure_oracle = {
         key: boundaries
         for key, (state, boundaries) in attempt_outcomes.items()
@@ -481,7 +575,7 @@ def _attempt_accounting_validate(ledger: dict) -> None:
         assert cell.get("claim_status") == next(iter(claim_states))
 
         attempt_pointers = [
-            (attempt_pointer["source"], attempt_pointer["json_pointer"])
+            _attempt_accounting_pointer_key(attempt_pointer)
             for attempt_pointer in cell["attempt_pointers"]
         ]
         attempt_states = [attempt_outcomes[key][0] for key in attempt_pointers]
@@ -546,40 +640,47 @@ def _attempt_accounting_validate(ledger: dict) -> None:
         cell_id = entry.get("cell_id")
         assert cell_id in cell_by_id
         attempt_pointer = entry.get("attempt_pointer")
-        assert isinstance(attempt_pointer, dict)
-        attempt_key = (
-            attempt_pointer.get("source"),
-            attempt_pointer.get("json_pointer"),
-        )
+        attempt_key = _attempt_accounting_pointer_key(attempt_pointer)
         assert attempt_key in attempt_failure_oracle
         assert attempt_key not in attempt_failures_by_pointer
         assert attempt_owner_by_pointer[attempt_key] == cell_id
         identity = entry.get("candidate_identity")
         assert isinstance(identity, dict)
-        assert any(
-            key in identity and _attempt_accounting_nonempty(identity[key])
-            for key in ("version", "hash", "config", "limitation")
+        expected_identity = _attempt_accounting_candidate_identity_for_attempt(
+            attempt_key[0], attempt_key[1], documents[attempt_key[0]]
         )
+        if expected_identity:
+            assert identity == expected_identity
+        else:
+            assert (
+                isinstance(identity.get("limitation"), str)
+                and identity["limitation"]
+            )
+            assert not any(
+                key in identity and _attempt_accounting_nonempty(identity[key])
+                for key in ("version", "hash", "config")
+            )
         boundary = entry.get("failure_boundary")
         assert isinstance(boundary, str) and boundary
         evidence = entry.get("evidence")
         assert isinstance(evidence, list) and evidence
         assert boundary == "; ".join(attempt_failure_oracle[attempt_key])
         for evidence_item in evidence:
-            assert isinstance(evidence_item, dict)
-            key = (
-                evidence_item.get("source"),
-                evidence_item.get("json_pointer"),
-            )
+            key = _attempt_accounting_pointer_key(evidence_item)
             assert key in failure_oracle
             assert key not in evidence_by_pointer
-            owner = owner_by_pointer.get(key, attempt_owner_by_pointer.get(key))
+            claim_key = (key[0], key[1])
+            owner = owner_by_pointer.get(claim_key, attempt_owner_by_pointer.get(key))
             assert owner == cell_id
-            record = oracle.get(key, attempt_oracle.get(key))
+            record = oracle.get(claim_key, attempt_oracle.get(key))
             assert isinstance(record, dict)
             for hash_key in ("raw_stream_sha256", "transcript_sha256"):
                 if isinstance(record.get(hash_key), str):
                     assert evidence_item.get(hash_key) == record[hash_key]
+                elif isinstance(record.get(hash_key), list):
+                    occurrence = key[2]
+                    assert occurrence < len(record[hash_key])
+                    assert evidence_item.get(hash_key) == record[hash_key][occurrence]
             evidence_by_pointer[key] = entry
         attempt_failures_by_pointer[attempt_key] = entry
 
@@ -4341,6 +4442,116 @@ class PolicyContractTests(unittest.TestCase):
         ledger_path = ROOT / "benchmarks" / "attempt-accounting.json"
         ledger = json.loads(ledger_path.read_text(encoding="utf-8"))
         _attempt_accounting_validate(ledger)
+
+        self.assertEqual(len(ledger["sources"]), 11)
+        self.assertEqual(
+            sum(len(cell["claim_pointers"]) for cell in ledger["cells"]), 193
+        )
+        self.assertEqual(
+            sum(len(cell["attempt_pointers"]) for cell in ledger["cells"]), 137
+        )
+        self.assertEqual(
+            sum(
+                cell["failed"]
+                for cell in ledger["cells"]
+                if cell["count_status"] == "known"
+            ),
+            37,
+        )
+
+        verifier_failed = next(
+            cell
+            for cell in ledger["cells"]
+            if cell["id"]
+            == "cell:benchmarks/verifier-boundary/results.json#failed"
+        )
+        self.assertEqual(
+            (verifier_failed["attempted"], verifier_failed["passed"], verifier_failed["failed"]),
+            (6, 0, 6),
+        )
+        verifier_failures = [
+            entry
+            for entry in ledger["failed_attempts"]
+            if entry["attempt_pointer"]["source"]
+            == "benchmarks/verifier-boundary/results.json"
+        ]
+        self.assertEqual(len(verifier_failures), 6)
+        self.assertEqual(
+            sorted(
+                entry["attempt_pointer"].get("occurrence", 0)
+                for entry in verifier_failures
+                if entry["attempt_pointer"]["json_pointer"] == "/failed_attempts/2"
+            ),
+            [0, 1],
+        )
+        self.assertEqual(
+            sorted(
+                entry["attempt_pointer"].get("occurrence", 0)
+                for entry in verifier_failures
+                if entry["attempt_pointer"]["json_pointer"] == "/failed_attempts/3"
+            ),
+            [0, 1],
+        )
+
+        hash_identity = deepcopy(ledger)
+        hash_entry = next(
+            entry
+            for entry in hash_identity["failed_attempts"]
+            if entry["attempt_pointer"]["source"]
+            == "benchmarks/verifier-boundary/results.json"
+            and entry["attempt_pointer"]["json_pointer"] == "/failed_attempts/2"
+            and entry["attempt_pointer"].get("occurrence", 0) == 0
+        )
+        hash_entry["candidate_identity"] = {
+            "limitation": "identity intentionally removed"
+        }
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(hash_identity)
+
+        config_identity = deepcopy(ledger)
+        config_entry = next(
+            entry
+            for entry in config_identity["failed_attempts"]
+            if entry["attempt_pointer"]["source"]
+            == "benchmarks/spontaneous-dispatch/issue-29-topology.json"
+        )
+        config_entry["candidate_identity"] = {
+            "limitation": "identity intentionally removed"
+        }
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(config_identity)
+
+        control_entry = next(
+            entry
+            for entry in ledger["failed_attempts"]
+            if entry["attempt_pointer"]["source"]
+            == "benchmarks/prompt-compression/results.json"
+            and entry["attempt_pointer"]["json_pointer"]
+            == "/behavioral_gates/spontaneous_mechanical_v1_3_3_control"
+        )
+        self.assertEqual(control_entry["candidate_identity"], {"version": "1.3.3"})
+
+        root_identity = deepcopy(ledger)
+        root_entry = next(
+            entry
+            for entry in root_identity["failed_attempts"]
+            if entry["id"] == control_entry["id"]
+        )
+        root_entry["candidate_identity"] = {"version": "1.3.4"}
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(root_identity)
+
+        control_limitation = deepcopy(ledger)
+        limitation_entry = next(
+            entry
+            for entry in control_limitation["failed_attempts"]
+            if entry["id"] == control_entry["id"]
+        )
+        limitation_entry["candidate_identity"] = {
+            "limitation": "identity intentionally removed"
+        }
+        with self.assertRaises(AssertionError):
+            _attempt_accounting_validate(control_limitation)
 
         missing_cell_mapping = deepcopy(ledger)
         cell = next(

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -41,6 +41,7 @@ ATTEMPT_ACCOUNTING_SOURCES = (
 ATTEMPT_ACCOUNTING_MARKERS = frozenset(
     {
         "claim",
+        "is_error",
         "status",
         "passed",
         "test_passed",
@@ -119,6 +120,9 @@ ATTEMPT_ACCOUNTING_ATTEMPT_ARRAY_KEYS = frozenset(
     }
 )
 ATTEMPT_ACCOUNTING_SINGULAR_ATTEMPTS = {
+    "benchmarks/baton-compatibility/results.json": (
+        "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe",
+    ),
     "benchmarks/baton-dispatch-effect/results.json": (
         "/release_payload_replay",
     ),
@@ -155,7 +159,22 @@ ATTEMPT_ACCOUNTING_REVIEWED_FAILURES = {
         "name": "uncollected-background-verification",
         "outcome": "approval gate held; acceptance not met",
     },
+    (
+        "benchmarks/baton-compatibility/results.json",
+        "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe",
+    ): {
+        "result": "EXPLICIT_OPUS_ROUTE_OK",
+        "observed_model": "claude-opus-4-8",
+    },
 }
+ATTEMPT_ACCOUNTING_REVIEWED_CLAIMS = frozenset(
+    {
+        (
+            "benchmarks/baton-compatibility/results.json",
+            "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe",
+        )
+    }
+)
 ATTEMPT_ACCOUNTING_IDENTITY_FIELDS = (
     ("policy_sha256", "hash"),
     ("policy_orchestration_sha256", "hash"),
@@ -312,7 +331,9 @@ def _attempt_accounting_outcome(
             record.get(field) == expected
             for field, expected in reviewed_failure.items()
         ):
-            return "failed", (f"reviewed_failure={reviewed_failure['name']}",)
+            label = reviewed_failure.get("name", reviewed_failure.get("result"))
+            assert isinstance(label, str) and label
+            return "failed", (f"reviewed_failure={label}",)
 
     boundaries: list[str] = []
     for key in ("passed", "test_passed", "topology_pass"):
@@ -322,6 +343,10 @@ def _attempt_accounting_outcome(
         boundaries.append("reachability=FAIL")
     if record.get("topology") == "FAIL":
         boundaries.append("topology=FAIL")
+    if record.get("is_error") is True:
+        boundaries.append("is_error=true")
+    if record.get("disposition") == "interrupted":
+        boundaries.append("disposition=interrupted")
     status = record.get("status")
     if status in ATTEMPT_ACCOUNTING_FAILURE_STATUSES:
         boundaries.append(f"status={status}")
@@ -529,6 +554,13 @@ def _attempt_accounting_validate(ledger: dict) -> None:
                 continue
             oracle[key] = record
             outcomes[key] = _attempt_accounting_outcome(record, source, pointer)
+    for source, pointer in ATTEMPT_ACCOUNTING_REVIEWED_CLAIMS:
+        key = (source, pointer)
+        assert key not in oracle
+        record = _attempt_accounting_resolve_pointer(documents[source], pointer)
+        assert isinstance(record, dict)
+        oracle[key] = record
+        outcomes[key] = _attempt_accounting_outcome(record, source, pointer)
 
     attempt_oracle = {}
     attempt_outcomes = {}
@@ -599,7 +631,9 @@ def _attempt_accounting_validate(ledger: dict) -> None:
             record.get(field) == expected
             for field, expected in reviewed_failure.items()
         )
-        boundary = (f"reviewed_failure={reviewed_failure['name']}",)
+        label = reviewed_failure.get("name", reviewed_failure.get("result"))
+        assert isinstance(label, str) and label
+        boundary = (f"reviewed_failure={label}",)
         for occurrence in range(
             _attempt_accounting_occurrence_count(source, pointer, record)
         ):
@@ -4496,10 +4530,10 @@ class PolicyContractTests(unittest.TestCase):
 
         self.assertEqual(len(ledger["sources"]), 11)
         self.assertEqual(
-            sum(len(cell["claim_pointers"]) for cell in ledger["cells"]), 196
+            sum(len(cell["claim_pointers"]) for cell in ledger["cells"]), 198
         )
         self.assertEqual(
-            sum(len(cell["attempt_pointers"]) for cell in ledger["cells"]), 137
+            sum(len(cell["attempt_pointers"]) for cell in ledger["cells"]), 138
         )
         self.assertEqual(
             sum(
@@ -4507,7 +4541,7 @@ class PolicyContractTests(unittest.TestCase):
                 for cell in ledger["cells"]
                 if cell["count_status"] == "known"
             ),
-            40,
+            42,
         )
 
         spontaneous_cells = {
@@ -4534,6 +4568,41 @@ class PolicyContractTests(unittest.TestCase):
         self.assertEqual(
             _attempt_accounting_outcome({"topology": "FAIL"}),
             ("failed", ("topology=FAIL",)),
+        )
+
+        baton_cells = {
+            cell["claim_status"]: cell
+            for cell in ledger["cells"]
+            if cell["id"].startswith(
+                "cell:benchmarks/baton-compatibility/results.json#"
+            )
+        }
+        self.assertEqual(
+            (
+                baton_cells["failed"]["attempted"],
+                baton_cells["failed"]["failed"],
+                len(baton_cells["unknown"]["attempt_pointers"]),
+            ),
+            (4, 4, 5),
+        )
+        self.assertEqual(
+            _attempt_accounting_outcome(
+                {"is_error": True, "disposition": "interrupted"}
+            ),
+            ("failed", ("is_error=true", "disposition=interrupted")),
+        )
+        baton_failure_pointers = {
+            entry["attempt_pointer"]["json_pointer"]
+            for entry in ledger["failed_attempts"]
+            if entry["attempt_pointer"]["source"]
+            == "benchmarks/baton-compatibility/results.json"
+        }
+        self.assertIn(
+            "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe",
+            baton_failure_pointers,
+        )
+        self.assertIn(
+            "/superseded_candidate_gate/turns/1", baton_failure_pointers
         )
 
         verifier_failed = next(


### PR DESCRIPTION
## Summary

- add a SHA-bound attempt ledger for all 11 public behavioral result sources without modifying historical evidence
- separate exhaustive claim coverage from actual attempt granularity, with explicit unknown and not-run semantics
- preserve all 35 known failed attempts with candidate identity, failure boundary, and source evidence
- reject source, claim, attempt, count, and failure drift through focused contract checks

## Verification

- focused attempt-accounting contract
- full repository suite: 72/72
- renderer check
- git diff check
- fresh outcome verifier: CONFIRMED

No live or paid gate was run.

Closes #65