### PR TITLE
feat(benchmarks): bind cue-free TUI attempts

### DIFF
--- a/benchmarks/spontaneous-dispatch/cue-free-tui.attempts.json
+++ b/benchmarks/spontaneous-dispatch/cue-free-tui.attempts.json
@@ -1,0 +1,161 @@
+{
+  "schema_version": 1,
+  "source": {
+    "path": "cue-free-tui.json",
+    "sha256": "0e8eae3338f2ee0e913ffc22c39770403ef4d49081d865bdd296b4b7a9854b81"
+  },
+  "counts": {
+    "attempted": 4,
+    "passed": 0,
+    "failed": 4
+  },
+  "coverage": {
+    "source_pointer": "",
+    "status": "stopped_after_failed_topology",
+    "invocation_pointers": [
+      "/campaign/cells/0",
+      "/campaign/cells/1",
+      "/campaign/cells/2",
+      "/campaign/cells/3"
+    ],
+    "claim": "A persistent Calico TUI run exposed four readable thinking blocks. The model treated a higher-priority client instruction as preventing AgentTool use, then independently selected direct work under the coordination-cost escape. It made no Agent call, changed all twelve adapters in the main session, and passed 12/12 tests.",
+    "claim_boundary": "This is one diagnostic run on one account, client build, model, prompt, fixture, and policy candidate. The thinking text is a model self-report, not a capture of the request's system-prompt bytes, so it identifies the model's stated decision basis but does not prove the exact active instruction text. The raw transcript is not committed because it contains local paths, session identifiers, plugin inventory, and chain-of-thought. The four-cell campaign disproves this candidate's required 2/2 mechanical topology; it is not a dispatch rate and does not establish that cue-free delegation is impossible."
+  },
+  "passed_attempts": [],
+  "failed_attempts": [
+    {
+      "id": "cue-free-tui-cell-0",
+      "source_pointer": "/campaign/cells/0",
+      "status": "correctness_passed_topology_blocked",
+      "candidate_identity": {
+        "candidate_sha256": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
+      },
+      "boundary": "topology_pass=false",
+      "surface": "Claude Code print, no persistence",
+      "route": {
+        "client_binary": "claude",
+        "client_version": "2.1.223",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "setting_sources": ["user", "project", "local"]
+      },
+      "cost_usd": 0.3896815,
+      "agent_calls": 0,
+      "main_session_mutated_source": true,
+      "changed_adapter_files": 12,
+      "tests": "12 passed, 0 failed",
+      "topology_pass": false,
+      "raw_stream_sha256": "1450396041edf779d74783d275214ee396fc8d0723af305b26bae875470c27ce"
+    },
+    {
+      "id": "cue-free-tui-cell-1",
+      "source_pointer": "/campaign/cells/1",
+      "status": "correctness_passed_topology_blocked",
+      "candidate_identity": {
+        "candidate_sha256": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
+      },
+      "boundary": "topology_pass=false",
+      "surface": "Claude Code print, persistent",
+      "route": {
+        "client_binary": "claude",
+        "client_version": "2.1.223",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "setting_sources": ["user", "project", "local"]
+      },
+      "cost_usd": 0.9816195,
+      "agent_calls": 0,
+      "main_session_mutated_source": true,
+      "changed_adapter_files": 12,
+      "tests": "12 passed, 0 failed",
+      "topology_pass": false,
+      "raw_stream_sha256": "84a6344cbb2864db20f3b0f00cdea680822c951c0d18dfec08db83e1420d6646"
+    },
+    {
+      "id": "cue-free-tui-cell-2",
+      "source_pointer": "/campaign/cells/2",
+      "status": "correctness_passed_topology_blocked",
+      "candidate_identity": {
+        "candidate_sha256": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
+      },
+      "boundary": "topology_pass=false",
+      "surface": "Calico print, persistent",
+      "route": {
+        "client_binary": "calico",
+        "client_version": "2.1.223",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "setting_sources": ["user", "project", "local"]
+      },
+      "cost_usd": 0.4468695,
+      "agent_calls": 0,
+      "main_session_mutated_source": true,
+      "changed_adapter_files": 12,
+      "tests": "12 passed, 0 failed",
+      "topology_pass": false,
+      "raw_stream_sha256": "dec95adb7fb773d552223e23e32b1bcd03c3f7ba8475e44bcf6de606f25f7d83"
+    },
+    {
+      "id": "cue-free-tui-cell-3",
+      "source_pointer": "/campaign/cells/3",
+      "status": "correctness_passed_topology_blocked",
+      "candidate_identity": {
+        "candidate_sha256": "5ecbbe9a797ba1269a20ac9a1aa3ba5182bf7d9da887ea889263ef9ee64c0564"
+      },
+      "boundary": "topology_pass=false",
+      "surface": "Calico interactive TUI, persistent",
+      "route": {
+        "client_binary": "calico",
+        "client_version": "2.1.223",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "setting_sources": ["user", "project", "local"],
+        "calico_source_base_commit": "fc2adbccd39c3502668421b4c89cdd5f4390a31d",
+        "calico_installed_binary_sha256": "163fddf37ac558c45346dee6d819c87bd96f3f6f1ee5610aef9451cfec46f9f5",
+        "calico_patch_modules_verified": 17,
+        "tool_call_verbose_enabled": true
+      },
+      "cost_usd": 0.82,
+      "cost_is_rounded": true,
+      "agent_calls": 0,
+      "main_session_mutated_source": true,
+      "changed_adapter_files": 12,
+      "tests": "12 passed, 0 failed",
+      "topology_pass": false,
+      "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad",
+      "tui_observation": {
+        "transcript_sha256": "a61987f9409683e9cb07262d8df0e6e9b1f30e693ac12fa9c226855eb79f48ad",
+        "thinking_blocks": 4,
+        "readable_thinking_blocks": 4,
+        "reasoning_summary": "The model treated a higher-priority system instruction as overriding the candidate policy's standing permission to call AgentTool. Separately, it judged the worker briefing cost greater than the twelve identical edits.",
+        "reasoning_verbatim_published": false,
+        "visible_dispatch_reason": "12 identical one-shot edits, mechanical but faster inline than briefing a worker.",
+        "top_level_tools": {
+          "Bash": 6
+        },
+        "agent_calls": 0,
+        "main_session_mutated_source": true,
+        "modified_paths": [
+          "src/adapters/alpha.js",
+          "src/adapters/bravo.js",
+          "src/adapters/charlie.js",
+          "src/adapters/delta.js",
+          "src/adapters/echo.js",
+          "src/adapters/foxtrot.js",
+          "src/adapters/golf.js",
+          "src/adapters/hotel.js",
+          "src/adapters/india.js",
+          "src/adapters/juliet.js",
+          "src/adapters/kilo.js",
+          "src/adapters/lima.js"
+        ],
+        "tests": "12 passed, 0 failed",
+        "full_tool_commands_and_output_visible": true,
+        "topology_pass": false,
+        "tui_displayed_cost_usd": 0.82,
+        "cost_is_rounded": true
+      }
+    }
+  ],
+  "not_run": []
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -602,6 +602,215 @@ class PolicyContractTests(unittest.TestCase):
             content = (ROOT / readme).read_text(encoding="utf-8")
             self.assertIn("cue-free-tui.json", content)
 
+    def test_cue_free_tui_attempts_are_source_bound(self) -> None:
+        benchmark = ROOT / "benchmarks" / "spontaneous-dispatch"
+        attempts = json.loads(
+            (benchmark / "cue-free-tui.attempts.json").read_text(
+                encoding="utf-8"
+            ),
+            parse_float=Decimal,
+        )
+        source_bytes = (benchmark / "cue-free-tui.json").read_bytes()
+        source = json.loads(source_bytes, parse_float=Decimal)
+
+        expected_source_keys = {
+            "campaign",
+            "claim",
+            "claim_boundary",
+            "disposition",
+            "inputs",
+            "run_date",
+            "schema_version",
+            "status",
+            "tui_observation",
+        }
+        expected_campaign_keys = {
+            "approximate_total_usd",
+            "authorized_cap_usd",
+            "cells",
+            "stopped_before_explicit_cue_cells",
+        }
+        expected_surfaces = [
+            "Claude Code print, no persistence",
+            "Claude Code print, persistent",
+            "Calico print, persistent",
+            "Calico interactive TUI, persistent",
+        ]
+        expected_pointers = [f"/campaign/cells/{index}" for index in range(4)]
+        expected_candidate_sha = source["inputs"]["policy"]["candidate_sha256"]
+        expected_behavior_keys = (
+            "agent_calls",
+            "main_session_mutated_source",
+            "changed_adapter_files",
+            "tests",
+            "topology_pass",
+        )
+
+        def resolve(pointer: str) -> dict:
+            self.assertTrue(pointer.startswith("/"))
+            value: object = source
+            for token in pointer[1:].split("/"):
+                if isinstance(value, dict):
+                    self.assertIn(token, value)
+                    value = value[token]
+                else:
+                    self.assertIsInstance(value, list)
+                    self.assertTrue(token.isdigit())
+                    value = value[int(token)]
+            self.assertIsInstance(value, dict)
+            return value
+
+        def validate(ledger: dict) -> None:
+            self.assertEqual(
+                set(ledger),
+                {
+                    "schema_version",
+                    "source",
+                    "counts",
+                    "coverage",
+                    "passed_attempts",
+                    "failed_attempts",
+                    "not_run",
+                },
+            )
+            self.assertEqual(set(source), expected_source_keys)
+            self.assertEqual(set(source["campaign"]), expected_campaign_keys)
+            self.assertEqual(
+                ledger["source"],
+                {
+                    "path": "cue-free-tui.json",
+                    "sha256": hashlib.sha256(source_bytes).hexdigest(),
+                },
+            )
+            self.assertEqual(ledger["schema_version"], 1)
+            self.assertEqual(ledger["coverage"]["source_pointer"], "")
+            self.assertEqual(ledger["coverage"]["status"], source["status"])
+            self.assertEqual(ledger["coverage"]["claim"], source["claim"])
+            self.assertEqual(
+                ledger["coverage"]["claim_boundary"], source["claim_boundary"]
+            )
+            self.assertEqual(
+                ledger["coverage"]["invocation_pointers"], expected_pointers
+            )
+            self.assertEqual(
+                [cell["surface"] for cell in source["campaign"]["cells"]],
+                expected_surfaces,
+            )
+            self.assertEqual(
+                [cell["surface"] for cell in source["campaign"]["cells"]],
+                [
+                    resolve(pointer)["surface"] for pointer in expected_pointers
+                ],
+            )
+
+            passed = ledger["passed_attempts"]
+            failed = ledger["failed_attempts"]
+            not_run = ledger["not_run"]
+            self.assertEqual(passed, [])
+            self.assertEqual(not_run, [])
+            self.assertEqual(len(failed), 4)
+            self.assertEqual(
+                ledger["counts"], {"attempted": 4, "passed": 0, "failed": 4}
+            )
+            self.assertEqual(ledger["counts"]["attempted"], len(failed))
+            self.assertEqual(
+                ledger["counts"]["attempted"],
+                ledger["counts"]["passed"] + ledger["counts"]["failed"],
+            )
+            self.assertEqual(
+                [entry["source_pointer"] for entry in failed], expected_pointers
+            )
+            self.assertNotIn("", [entry["source_pointer"] for entry in failed])
+            self.assertEqual(
+                len({entry["id"] for entry in failed}), len(failed)
+            )
+            self.assertEqual(
+                len({entry["source_pointer"] for entry in failed}), len(failed)
+            )
+
+            for index, (entry, pointer) in enumerate(zip(failed, expected_pointers)):
+                cell = resolve(pointer)
+                self.assertEqual(entry["id"], f"cue-free-tui-cell-{index}")
+                self.assertEqual(entry["status"], "correctness_passed_topology_blocked")
+                self.assertEqual(
+                    entry["candidate_identity"],
+                    {"candidate_sha256": expected_candidate_sha},
+                )
+                self.assertEqual(entry["boundary"], "topology_pass=false")
+                self.assertEqual(entry["surface"], cell["surface"])
+                self.assertEqual(entry["route"], cell["route"])
+                self.assertEqual(entry["cost_usd"], cell["cost_usd"])
+                for key in expected_behavior_keys:
+                    self.assertEqual(entry[key], cell[key])
+                self.assertRegex(entry["status"], r"topology")
+                self.assertNotIn("client_reported_cost_usd", entry)
+
+                if index < 3:
+                    self.assertEqual(
+                        entry["raw_stream_sha256"], cell["raw_stream_sha256"]
+                    )
+                    self.assertRegex(
+                        entry["raw_stream_sha256"], r"^[0-9a-f]{64}$"
+                    )
+                    self.assertNotIn("transcript_sha256", entry)
+                    self.assertNotIn("tui_observation", entry)
+                    self.assertNotIn("cost_is_rounded", entry)
+                else:
+                    self.assertTrue(entry["cost_is_rounded"])
+                    self.assertEqual(
+                        entry["transcript_sha256"], cell["transcript_sha256"]
+                    )
+                    self.assertEqual(
+                        entry["transcript_sha256"],
+                        source["tui_observation"]["transcript_sha256"],
+                    )
+                    self.assertRegex(
+                        entry["transcript_sha256"], r"^[0-9a-f]{64}$"
+                    )
+                    self.assertEqual(
+                        entry["tui_observation"], source["tui_observation"]
+                    )
+                    self.assertNotIn("raw_stream_sha256", entry)
+                    self.assertEqual(
+                        entry["tui_observation"]["cost_is_rounded"],
+                        entry["cost_is_rounded"],
+                    )
+
+            self.assertEqual(
+                sum((cell["cost_usd"] for cell in source["campaign"]["cells"]), Decimal("0")),
+                source["campaign"]["approximate_total_usd"],
+            )
+
+        validate(attempts)
+
+        missing_cell = deepcopy(attempts)
+        missing_cell["failed_attempts"].pop()
+        with self.assertRaises(AssertionError):
+            validate(missing_cell)
+
+        root_attempt = deepcopy(attempts)
+        root_attempt["failed_attempts"].append(
+            deepcopy(root_attempt["failed_attempts"][0])
+        )
+        root_attempt["failed_attempts"][-1]["id"] = "cue-free-tui-root"
+        root_attempt["failed_attempts"][-1]["source_pointer"] = ""
+        with self.assertRaises(AssertionError):
+            validate(root_attempt)
+
+        replaced_candidate = deepcopy(attempts)
+        replaced_candidate["failed_attempts"][0]["candidate_identity"][
+            "candidate_sha256"
+        ] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(replaced_candidate)
+
+        misplaced_transcript = deepcopy(attempts)
+        misplaced_transcript["failed_attempts"][0]["transcript_sha256"] = (
+            source["tui_observation"]["transcript_sha256"]
+        )
+        with self.assertRaises(AssertionError):
+            validate(misplaced_transcript)
+
     def test_issue_29_reachability_correction_is_self_consistent(self) -> None:
         path = ROOT / "benchmarks" / "spontaneous-dispatch"
         evidence = json.loads(


### PR DESCRIPTION
## Summary

- add a source-bound canonical sidecar for the four cue-free TUI campaign invocations
- preserve the shared candidate policy identity and all four topology failures
- bind print runs to their own raw streams and the interactive TUI run exclusively to its transcript
- retain source-native cost semantics, including the rounded TUI observation
- validate the exact four-cell source shape with focused tamper checks

## Verification

- focused cue-free TUI attempt contract
- full repository suite: 73/73
- renderer check
- git diff check
- fresh outcome verifier: CONFIRMED

This is the second vertical slice of #65. It does not claim coverage of other spontaneous-dispatch records and does not close the issue.

Refs #65