### PR TITLE
feat(benchmarks): bind dispatch-brake runs

### DIFF
--- a/benchmarks/dispatch-brake/attempts.json
+++ b/benchmarks/dispatch-brake/attempts.json
@@ -1,0 +1,200 @@
+{
+  "schema_version": 1,
+  "source": {
+    "path": "results.json",
+    "sha256": "4db849669b49386911ded403352b857d2341fe147f0223f262d34d1d04bc17df"
+  },
+  "counts": {
+    "attempted": 6,
+    "passed": 6,
+    "failed": 0
+  },
+  "coverage": {
+    "source_pointer": "/runs",
+    "invocation_pointers": [
+      "/runs/0",
+      "/runs/1",
+      "/runs/2",
+      "/runs/3",
+      "/runs/4",
+      "/runs/5"
+    ]
+  },
+  "passed_attempts": [
+    {
+      "id": "dispatch-brake-pilotfish-current",
+      "source_pointer": "/runs/0",
+      "name": "pilotfish-current",
+      "configuration_identity": "installed pilotfish v1.1.5 baseline",
+      "status": "success",
+      "wall_seconds": 101.21,
+      "duration_ms": 99480,
+      "num_turns": 17,
+      "reported_cost_usd": 0.460236,
+      "tests_passed": 2,
+      "tests_failed": 0,
+      "agent_calls": [],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "input_tokens": 22,
+          "output_tokens": 5891,
+          "cache_read_input_tokens": 233062,
+          "cache_creation_input_tokens": 19632,
+          "reported_cost_usd": 0.460236
+        }
+      },
+      "raw_stream_sha256": "761e94c099ebe5566c43667135722dc8c5abd856585eaf8ef0f4a78b78b8b169"
+    },
+    {
+      "id": "dispatch-brake-remora-current",
+      "source_pointer": "/runs/1",
+      "name": "remora-current",
+      "configuration_identity": "remora v0.1.6 baseline",
+      "status": "success",
+      "wall_seconds": 322.90,
+      "duration_ms": 321616,
+      "num_turns": 17,
+      "reported_cost_usd": 1.316911,
+      "tests_passed": 2,
+      "tests_failed": 0,
+      "agent_calls": [
+        {
+          "role": "scout",
+          "run_in_background": false,
+          "description": "Diagnose status-line failure"
+        },
+        {
+          "role": "executor",
+          "run_in_background": false,
+          "description": "Fix status-line reducer"
+        },
+        {
+          "role": "verifier",
+          "run_in_background": true,
+          "description": "Verify status-line fix"
+        }
+      ],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "input_tokens": 80342,
+          "output_tokens": 8482,
+          "cache_read_input_tokens": 461824,
+          "cache_creation_input_tokens": 0,
+          "reported_cost_usd": 0.844672
+        },
+        "gpt-5.6-luna": {
+          "input_tokens": 47145,
+          "output_tokens": 5426,
+          "cache_read_input_tokens": 201728,
+          "cache_creation_input_tokens": 0,
+          "reported_cost_usd": 0.472239
+        }
+      },
+      "raw_stream_sha256": "45d2eb9b83220e522c817b53d498ad004ddd1ac1b6ca2d9166c1ed222777d3c3"
+    },
+    {
+      "id": "dispatch-brake-pilotfish-candidate",
+      "source_pointer": "/runs/2",
+      "name": "pilotfish-candidate",
+      "configuration_identity": "development dispatch-brake candidate",
+      "status": "success",
+      "wall_seconds": 83.99,
+      "duration_ms": 82371,
+      "num_turns": 13,
+      "reported_cost_usd": 0.439315,
+      "tests_passed": 2,
+      "tests_failed": 0,
+      "agent_calls": [],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "input_tokens": 12,
+          "output_tokens": 5167,
+          "cache_read_input_tokens": 105020,
+          "cache_creation_input_tokens": 25757,
+          "reported_cost_usd": 0.439315
+        }
+      },
+      "raw_stream_sha256": "28ec9eb5f7f2d7222f2b7933faa2cf0185225f19300ece65a3dcdc9965125d02"
+    },
+    {
+      "id": "dispatch-brake-remora-candidate",
+      "source_pointer": "/runs/3",
+      "name": "remora-candidate",
+      "configuration_identity": "development dispatch-brake candidate without the final verifier rule",
+      "status": "success",
+      "wall_seconds": 89.76,
+      "duration_ms": 88295,
+      "num_turns": 22,
+      "reported_cost_usd": 0.455722,
+      "tests_passed": 2,
+      "tests_failed": 0,
+      "agent_calls": [],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "input_tokens": 39875,
+          "output_tokens": 2451,
+          "cache_read_input_tokens": 390144,
+          "cache_creation_input_tokens": 0,
+          "reported_cost_usd": 0.455722
+        }
+      },
+      "raw_stream_sha256": "fd674113376254b00f861fae38e1c6dab242eb6db483723f0f4023276cd30148"
+    },
+    {
+      "id": "dispatch-brake-pilotfish-postpatch",
+      "source_pointer": "/runs/4",
+      "name": "pilotfish-postpatch",
+      "configuration_identity": "exact repository policy with dispatch brake",
+      "status": "success",
+      "wall_seconds": 83.70,
+      "duration_ms": 82067,
+      "num_turns": 11,
+      "reported_cost_usd": 0.401433,
+      "tests_passed": 2,
+      "tests_failed": 0,
+      "agent_calls": [],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "input_tokens": 14,
+          "output_tokens": 5212,
+          "cache_read_input_tokens": 142246,
+          "cache_creation_input_tokens": 19994,
+          "reported_cost_usd": 0.401433
+        }
+      },
+      "raw_stream_sha256": "3e4e226969b0973a3baa53ae2d2f00971d3bcb143b058c48172bd5978372f640"
+    },
+    {
+      "id": "dispatch-brake-remora-postpatch",
+      "source_pointer": "/runs/5",
+      "name": "remora-postpatch",
+      "configuration_identity": "exact repository policy with dispatch brake and verifier gate",
+      "status": "success",
+      "wall_seconds": 244.24,
+      "duration_ms": 242638,
+      "num_turns": 33,
+      "reported_cost_usd": 0.790973,
+      "tests_passed": 2,
+      "tests_failed": 0,
+      "agent_calls": [
+        {
+          "role": "verifier",
+          "run_in_background": true,
+          "description": "Verify status-line fix"
+        }
+      ],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "input_tokens": 48594,
+          "output_tokens": 10779,
+          "cache_read_input_tokens": 557056,
+          "cache_creation_input_tokens": 0,
+          "reported_cost_usd": 0.790973
+        }
+      },
+      "raw_stream_sha256": "f50e1b2241b13a3aad2ea101d8731258cd694bef0e88f54f68673630d0a1764e"
+    }
+  ],
+  "failed_attempts": [],
+  "not_run": []
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -2909,6 +2909,214 @@ class PolicyContractTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             validate(replaced_evidence)
 
+    def test_dispatch_brake_attempts_are_source_bound(self) -> None:
+        benchmark = ROOT / "benchmarks" / "dispatch-brake"
+        attempts = json.loads(
+            (benchmark / "attempts.json").read_text(encoding="utf-8"),
+            parse_float=Decimal,
+        )
+        source_bytes = (benchmark / "results.json").read_bytes()
+        source = json.loads(source_bytes, parse_float=Decimal)
+        expected_source_keys = {
+            "schema_version",
+            "run_date",
+            "timezone",
+            "environment",
+            "source_commits",
+            "runs",
+            "primary_comparison",
+            "positive_control_extension",
+        }
+        expected_names = [
+            "pilotfish-current",
+            "remora-current",
+            "pilotfish-candidate",
+            "remora-candidate",
+            "pilotfish-postpatch",
+            "remora-postpatch",
+        ]
+        expected_pointers = [f"/runs/{index}" for index in range(6)]
+        expected_ledger_keys = {
+            "schema_version",
+            "source",
+            "counts",
+            "coverage",
+            "passed_attempts",
+            "failed_attempts",
+            "not_run",
+        }
+        common_entry_keys = {
+            "id",
+            "source_pointer",
+            "name",
+            "configuration_identity",
+            "status",
+            "wall_seconds",
+            "duration_ms",
+            "num_turns",
+            "reported_cost_usd",
+            "tests_passed",
+            "tests_failed",
+            "agent_calls",
+            "raw_stream_sha256",
+        }
+
+        def resolve(pointer: str) -> dict:
+            self.assertTrue(pointer.startswith("/"))
+            self.assertNotEqual(pointer, "/")
+            value: object = source
+            for token in pointer[1:].split("/"):
+                if isinstance(value, dict):
+                    self.assertIn(token, value)
+                    value = value[token]
+                elif isinstance(value, list):
+                    self.assertTrue(token.isdigit())
+                    index = int(token)
+                    self.assertLess(index, len(value))
+                    value = value[index]
+                else:
+                    self.fail(f"cannot resolve {pointer!r}")
+            self.assertIsInstance(value, dict)
+            return value
+
+        def validate(ledger: dict) -> None:
+            self.assertEqual(set(ledger), expected_ledger_keys)
+            self.assertEqual(set(source), expected_source_keys)
+            self.assertEqual(len(source["runs"]), 6)
+            self.assertEqual(
+                [run["name"] for run in source["runs"]], expected_names
+            )
+            self.assertEqual(ledger["schema_version"], 1)
+            self.assertEqual(
+                ledger["source"],
+                {
+                    "path": "results.json",
+                    "sha256": hashlib.sha256(source_bytes).hexdigest(),
+                },
+            )
+            self.assertEqual(
+                ledger["coverage"],
+                {
+                    "source_pointer": "/runs",
+                    "invocation_pointers": expected_pointers,
+                },
+            )
+
+            passed = ledger["passed_attempts"]
+            failed = ledger["failed_attempts"]
+            not_run = ledger["not_run"]
+            self.assertEqual(len(passed), 6)
+            self.assertEqual(failed, [])
+            self.assertEqual(not_run, [])
+            self.assertEqual(
+                ledger["counts"], {"attempted": 6, "passed": 6, "failed": 0}
+            )
+            self.assertEqual(ledger["counts"]["attempted"], len(passed) + len(failed))
+            self.assertEqual(
+                ledger["counts"]["attempted"],
+                ledger["counts"]["passed"] + ledger["counts"]["failed"],
+            )
+            self.assertEqual(
+                [entry["source_pointer"] for entry in passed], expected_pointers
+            )
+            self.assertEqual(
+                len({entry["id"] for entry in passed}), len(passed)
+            )
+            self.assertEqual(
+                len({entry["source_pointer"] for entry in passed}), len(passed)
+            )
+            self.assertEqual(
+                set(entry["source_pointer"] for entry in passed),
+                set(expected_pointers),
+            )
+            for forbidden_pointer in (
+                "/",
+                "/primary_comparison",
+                "/positive_control_extension",
+            ):
+                self.assertNotIn(
+                    forbidden_pointer,
+                    [entry["source_pointer"] for entry in passed],
+                )
+
+            for index, (entry, pointer, name) in enumerate(
+                zip(passed, expected_pointers, expected_names)
+            ):
+                run = resolve(pointer)
+                expected_entry_keys = common_entry_keys | (
+                    {"model_usage"} if "model_usage" in run else set()
+                )
+                self.assertEqual(set(entry), expected_entry_keys)
+                self.assertEqual(entry["id"], f"dispatch-brake-{name}")
+                self.assertEqual(entry["source_pointer"], pointer)
+                self.assertEqual(entry["name"], name)
+                self.assertEqual(entry["name"], run["name"])
+                self.assertEqual(
+                    entry["configuration_identity"], run["policy"]
+                )
+                self.assertEqual(entry["status"], "success")
+                self.assertEqual(entry["status"], run["status"])
+                self.assertEqual(entry["tests_passed"], 2)
+                self.assertEqual(entry["tests_failed"], 0)
+                self.assertEqual(entry["tests_passed"], run["tests_passed"])
+                self.assertEqual(entry["tests_failed"], run["tests_failed"])
+                for key in (
+                    "wall_seconds",
+                    "duration_ms",
+                    "num_turns",
+                    "reported_cost_usd",
+                    "agent_calls",
+                    "raw_stream_sha256",
+                ):
+                    if key in run:
+                        self.assertIn(key, entry)
+                        self.assertEqual(entry[key], run[key])
+                    else:
+                        self.assertNotIn(key, entry)
+                if "model_usage" in run:
+                    self.assertEqual(entry["model_usage"], run["model_usage"])
+                else:
+                    self.assertNotIn("model_usage", entry)
+                self.assertNotIn("cost_usd", entry)
+                self.assertRegex(entry["raw_stream_sha256"], r"^[0-9a-f]{64}$")
+                self.assertEqual(index, int(pointer.rsplit("/", 1)[1]))
+
+        validate(attempts)
+
+        missing_run = deepcopy(attempts)
+        missing_run["passed_attempts"].pop()
+        with self.assertRaises(AssertionError):
+            validate(missing_run)
+
+        for invalid_pointer in (
+            "/",
+            "/primary_comparison",
+            "/positive_control_extension",
+        ):
+            invalid_pointer_ledger = deepcopy(attempts)
+            invalid_pointer_ledger["passed_attempts"][0][
+                "source_pointer"
+            ] = invalid_pointer
+            with self.assertRaises(AssertionError):
+                validate(invalid_pointer_ledger)
+
+        replaced_policy = deepcopy(attempts)
+        replaced_policy["passed_attempts"][0][
+            "configuration_identity"
+        ] = "different policy"
+        with self.assertRaises(AssertionError):
+            validate(replaced_policy)
+
+        replaced_hash = deepcopy(attempts)
+        replaced_hash["passed_attempts"][0]["raw_stream_sha256"] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(replaced_hash)
+
+        replaced_cost = deepcopy(attempts)
+        replaced_cost["passed_attempts"][0]["reported_cost_usd"] = Decimal("0")
+        with self.assertRaises(AssertionError):
+            validate(replaced_cost)
+
     def test_installer_requires_tool_enforcing_runtime(self) -> None:
         installer = (ROOT / "install/AGENT-INSTALL.md").read_text(encoding="utf-8")
         self.assertIn("claude --version", installer)


### PR DESCRIPTION
## Summary

- add a source-bound canonical sidecar for the six flat first-phase dispatch-brake runs
- preserve per-run policy identity, metrics, reported cost, Agent calls, model usage, and raw-stream evidence
- keep primary comparison, positive-control links, root, and child Agent calls outside attempt accounting
- scope success to completed execution with 2/0 tests, without adding recommendation or causality claims
- validate exact source shape with focused tamper checks

## Verification

- focused dispatch-brake attempt contract
- full repository suite: 74/74
- renderer check
- git diff check
- fresh outcome verifier: CONFIRMED

This is the third vertical slice of #65. It excludes positive-controls and does not close the issue.

Refs #65