### PR TITLE
feat(benchmarks): bind dispatch positive controls

### DIFF
--- a/benchmarks/dispatch-brake/positive-controls/attempts.json
+++ b/benchmarks/dispatch-brake/positive-controls/attempts.json
@@ -1,0 +1,620 @@
+{
+  "schema_version": 1,
+  "source": {
+    "path": "results.json",
+    "sha256": "f8bb489168cc387b9f51db4d5a4095316e0714e7b7fd328fcbbd691c060b269b"
+  },
+  "counts": {
+    "attempted": 13,
+    "passed": 8,
+    "failed": 5
+  },
+  "coverage": {
+    "source_pointers": [
+      "/complete_runs",
+      "/interrupted_policy_probes"
+    ],
+    "invocation_pointers": [
+      "/complete_runs/0",
+      "/complete_runs/1",
+      "/complete_runs/2",
+      "/complete_runs/3",
+      "/complete_runs/4",
+      "/complete_runs/5",
+      "/complete_runs/6",
+      "/complete_runs/7",
+      "/complete_runs/8",
+      "/interrupted_policy_probes/0",
+      "/interrupted_policy_probes/1",
+      "/interrupted_policy_probes/2",
+      "/interrupted_policy_probes/3"
+    ]
+  },
+  "passed_attempts": [
+    {
+      "id": "dispatch-brake-positive-control-research-pilotfish-hard-brake",
+      "source_pointer": "/complete_runs/0",
+      "name": "research-pilotfish-hard-brake",
+      "configuration_identity": {
+        "fixture": "small-readonly-research",
+        "surface": "pilotfish",
+        "policy_iteration": "direct-work hard veto"
+      },
+      "status": "success",
+      "wall_seconds": 234.1,
+      "duration_ms": 231897,
+      "num_turns": 17,
+      "reported_cost_usd": 0.8968640000000001,
+      "tests_passed": 1,
+      "tests_failed": 0,
+      "agent_calls": [],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "inputTokens": 14,
+          "outputTokens": 15095,
+          "cacheReadInputTokens": 185058,
+          "cacheCreationInputTokens": 42689,
+          "webSearchRequests": 0,
+          "costUSD": 0.8968640000000001,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 64000
+        }
+      },
+      "raw_stream_sha256": "fc103c64d6fa0e065fd43db7a543b052156e168bb2558a66fa5847d1a8dc1906"
+    },
+    {
+      "id": "dispatch-brake-positive-control-mechanical-pilotfish-hard-brake",
+      "source_pointer": "/complete_runs/2",
+      "name": "mechanical-pilotfish-hard-brake",
+      "configuration_identity": {
+        "fixture": "stable-mechanical-12-file",
+        "surface": "pilotfish",
+        "policy_iteration": "direct-work hard veto"
+      },
+      "status": "success",
+      "wall_seconds": 128.24,
+      "duration_ms": 122578,
+      "num_turns": 28,
+      "reported_cost_usd": 0.790263,
+      "tests_passed": 12,
+      "tests_failed": 0,
+      "agent_calls": [],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "inputTokens": 12,
+          "outputTokens": 8313,
+          "cacheReadInputTokens": 99276,
+          "cacheCreationInputTokens": 53274,
+          "webSearchRequests": 0,
+          "costUSD": 0.790263,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 64000
+        }
+      },
+      "raw_stream_sha256": "fadd2be8d3660b8f9d676c57493fb79ede49b4f7b49d7d9ba58229685a946365"
+    },
+    {
+      "id": "dispatch-brake-positive-control-mechanical-remora-hard-brake",
+      "source_pointer": "/complete_runs/3",
+      "name": "mechanical-remora-hard-brake",
+      "configuration_identity": {
+        "fixture": "stable-mechanical-12-file",
+        "surface": "remora",
+        "policy_iteration": "direct-work hard veto"
+      },
+      "status": "success",
+      "wall_seconds": 260.46,
+      "duration_ms": 256502,
+      "num_turns": 15,
+      "reported_cost_usd": 1.010412,
+      "tests_passed": 12,
+      "tests_failed": 0,
+      "agent_calls": [
+        {
+          "subagent_type": "mech-executor",
+          "description": "Normalize all adapters",
+          "run_in_background": false
+        },
+        {
+          "subagent_type": "verifier",
+          "description": "Verify adapter normalization",
+          "run_in_background": false
+        }
+      ],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "inputTokens": 65735,
+          "outputTokens": 6371,
+          "cacheReadInputTokens": 275456,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.6256780000000001,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        },
+        "gpt-5.6-luna": {
+          "inputTokens": 31697,
+          "outputTokens": 4657,
+          "cacheReadInputTokens": 219648,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.3847340000000001,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        }
+      },
+      "raw_stream_sha256": "844ee44e97f65a9d8d909778fbf88a9378e98aa27fa33fd6c55627e2500503f1"
+    },
+    {
+      "id": "dispatch-brake-positive-control-research-pilotfish-broad-net-benefit",
+      "source_pointer": "/complete_runs/4",
+      "name": "research-pilotfish-broad-net-benefit",
+      "configuration_identity": {
+        "fixture": "small-readonly-research",
+        "surface": "pilotfish",
+        "policy_iteration": "broad net-benefit positive default"
+      },
+      "status": "success",
+      "wall_seconds": 261.52,
+      "duration_ms": 158489,
+      "num_turns": 11,
+      "reported_cost_usd": 1.0368928,
+      "tests_passed": 1,
+      "tests_failed": 0,
+      "agent_calls": [
+        {
+          "subagent_type": "scout",
+          "description": "Audit surface-a orchestration",
+          "run_in_background": true
+        },
+        {
+          "subagent_type": "scout",
+          "description": "Audit surface-b orchestration",
+          "run_in_background": true
+        }
+      ],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "inputTokens": 20,
+          "outputTokens": 15417,
+          "cacheReadInputTokens": 285369,
+          "cacheCreationInputTokens": 45129,
+          "webSearchRequests": 0,
+          "costUSD": 0.9794995,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 64000
+        },
+        "claude-haiku-4-5-20251001": {
+          "inputTokens": 52,
+          "outputTokens": 5277,
+          "cacheReadInputTokens": 26013,
+          "cacheCreationInputTokens": 22684,
+          "webSearchRequests": 0,
+          "costUSD": 0.0573933,
+          "contextWindow": 200000,
+          "maxOutputTokens": 32000
+        }
+      },
+      "raw_stream_sha256": "14d0e5032a6b94411efbda8d8a9005c96171e45522045fedfe6bff7170daeebd"
+    },
+    {
+      "id": "dispatch-brake-positive-control-mechanical-pilotfish-balanced",
+      "source_pointer": "/complete_runs/5",
+      "name": "mechanical-pilotfish-balanced",
+      "configuration_identity": {
+        "fixture": "stable-mechanical-12-file",
+        "surface": "pilotfish",
+        "policy_iteration": "net benefit plus single-bug guard"
+      },
+      "status": "success",
+      "wall_seconds": 138.4,
+      "duration_ms": 136864,
+      "num_turns": 5,
+      "reported_cost_usd": 0.50568165,
+      "tests_passed": 12,
+      "tests_failed": 0,
+      "agent_calls": [
+        {
+          "subagent_type": "mech-executor",
+          "description": "Normalize adapters in src/adapters",
+          "run_in_background": false
+        }
+      ],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "inputTokens": 10,
+          "outputTokens": 5378,
+          "cacheReadInputTokens": 95765,
+          "cacheCreationInputTokens": 20242,
+          "webSearchRequests": 0,
+          "costUSD": 0.3848025,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 64000
+        },
+        "claude-sonnet-5": {
+          "inputTokens": 12,
+          "outputTokens": 1325,
+          "cacheReadInputTokens": 90623,
+          "cacheCreationInputTokens": 19675,
+          "webSearchRequests": 0,
+          "costUSD": 0.12087915,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 64000
+        }
+      },
+      "raw_stream_sha256": "a888213aaf1e801e51c075b919a8965ec81f87601298b3fade47a2dc159321de"
+    },
+    {
+      "id": "dispatch-brake-positive-control-negative-pilotfish-balanced",
+      "source_pointer": "/complete_runs/6",
+      "name": "negative-pilotfish-balanced",
+      "configuration_identity": {
+        "fixture": "tightly-coupled-state-clone",
+        "surface": "pilotfish",
+        "policy_iteration": "net benefit plus single-bug guard"
+      },
+      "status": "success",
+      "wall_seconds": 77.45,
+      "duration_ms": 75746,
+      "num_turns": 10,
+      "reported_cost_usd": 0.36530899999999994,
+      "tests_passed": 2,
+      "tests_failed": 0,
+      "agent_calls": [],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "inputTokens": 12,
+          "outputTokens": 4654,
+          "cacheReadInputTokens": 115758,
+          "cacheCreationInputTokens": 19102,
+          "webSearchRequests": 0,
+          "costUSD": 0.36530899999999994,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 64000
+        }
+      },
+      "raw_stream_sha256": "fa00625b3b41326732368a5bf223f6b52f374f6df4fcce27b86307ad32e8f881"
+    },
+    {
+      "id": "dispatch-brake-positive-control-negative-remora-balanced",
+      "source_pointer": "/complete_runs/7",
+      "name": "negative-remora-balanced",
+      "configuration_identity": {
+        "fixture": "tightly-coupled-state-clone",
+        "surface": "remora",
+        "policy_iteration": "net benefit plus single-bug guard"
+      },
+      "status": "success",
+      "wall_seconds": 200.86,
+      "duration_ms": 199454,
+      "num_turns": 24,
+      "reported_cost_usd": 0.817504,
+      "tests_passed": 2,
+      "tests_failed": 0,
+      "agent_calls": [
+        {
+          "subagent_type": "verifier",
+          "description": "驗證 status-line 修正",
+          "run_in_background": false
+        }
+      ],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "inputTokens": 71423,
+          "outputTokens": 8237,
+          "cacheReadInputTokens": 508928,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.817504,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        }
+      },
+      "raw_stream_sha256": "4e1da242a30cff7977f1635dd41358082d00c205db39d988a658bc7db98d598c"
+    },
+    {
+      "id": "dispatch-brake-positive-control-research-pilotfish-sized-gate",
+      "source_pointer": "/complete_runs/8",
+      "name": "research-pilotfish-sized-gate",
+      "configuration_identity": {
+        "fixture": "small-readonly-research",
+        "surface": "pilotfish",
+        "policy_iteration": "final sized read-only gate"
+      },
+      "status": "success",
+      "wall_seconds": 228.96,
+      "duration_ms": 226618,
+      "num_turns": 18,
+      "reported_cost_usd": 0.918431,
+      "tests_passed": 1,
+      "tests_failed": 0,
+      "agent_calls": [],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "inputTokens": 16,
+          "outputTokens": 15030,
+          "cacheReadInputTokens": 220062,
+          "cacheCreationInputTokens": 43257,
+          "webSearchRequests": 0,
+          "costUSD": 0.918431,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 64000
+        }
+      },
+      "raw_stream_sha256": "21868a56f652be79b28562d531ae8a0fa46d418bdc5502ae5bb0b5cd450baa68"
+    }
+  ],
+  "failed_attempts": [
+    {
+      "id": "dispatch-brake-positive-control-research-remora-hard-brake",
+      "source_pointer": "/complete_runs/1",
+      "name": "research-remora-hard-brake",
+      "configuration_identity": {
+        "fixture": "small-readonly-research",
+        "surface": "remora",
+        "policy_iteration": "direct-work hard veto"
+      },
+      "status": "error_max_budget_usd",
+      "wall_seconds": 288.79,
+      "duration_ms": 4,
+      "num_turns": 1,
+      "reported_cost_usd": 3.1560490000000003,
+      "tests_passed": 1,
+      "tests_failed": 0,
+      "agent_calls": [
+        {
+          "subagent_type": "scout",
+          "description": "稽核 surface-a 規則",
+          "run_in_background": true
+        },
+        {
+          "subagent_type": "scout",
+          "description": "稽核 surface-b 規則",
+          "run_in_background": true
+        },
+        {
+          "subagent_type": "verifier",
+          "description": "驗證報告引用與結論",
+          "run_in_background": true
+        }
+      ],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "inputTokens": 341677,
+          "outputTokens": 10691,
+          "cacheReadInputTokens": 1697280,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 2.8243,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        },
+        "gpt-5.6-luna": {
+          "inputTokens": 31147,
+          "outputTokens": 6846,
+          "cacheReadInputTokens": 9728,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.33174899999999996,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        }
+      },
+      "raw_stream_sha256": "461dc2b7595384ef425276193a3fd3a73261f2f69353cc9254fecfc7af0edab9",
+      "note": "REPORT.md and its acceptance test completed; the run then exhausted the USD 3 client budget while finalizing fresh verification."
+    },
+    {
+      "id": "dispatch-brake-positive-control-negative-remora-broad-net-benefit",
+      "source_pointer": "/interrupted_policy_probes/0",
+      "name": "negative-remora-broad-net-benefit",
+      "configuration_identity": {
+        "fixture": "tightly-coupled-state-clone",
+        "surface": "remora",
+        "policy_iteration": "broad net-benefit before single-bug guard"
+      },
+      "status": "error_during_execution",
+      "wall_seconds": 118.27,
+      "duration_ms": 116943,
+      "num_turns": 20,
+      "reported_cost_usd": 0.328834,
+      "tests_passed": null,
+      "tests_failed": null,
+      "agent_calls": [
+        {
+          "subagent_type": "scout",
+          "description": "定位 status-line 失敗",
+          "run_in_background": false
+        },
+        {
+          "subagent_type": "executor",
+          "description": "修正 status-line 狀態同步",
+          "run_in_background": false
+        }
+      ],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "inputTokens": 15216,
+          "outputTokens": 2187,
+          "cacheReadInputTokens": 167936,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.214723,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        },
+        "gpt-5.6-luna": {
+          "inputTokens": 8336,
+          "outputTokens": 2631,
+          "cacheReadInputTokens": 13312,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.11411099999999999,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        }
+      },
+      "raw_stream_sha256": "b342e11e090df2594717c3029ef93692386d3ff984435c71da2331df85e5b7f3",
+      "stop_reason": "Stopped after observing a foreground scout followed by a foreground executor, which violated the intended single-reasoning-chain boundary."
+    },
+    {
+      "id": "dispatch-brake-positive-control-research-pilotfish-size-wording-rejected",
+      "source_pointer": "/interrupted_policy_probes/1",
+      "name": "research-pilotfish-size-wording-rejected",
+      "configuration_identity": {
+        "fixture": "small-readonly-research",
+        "surface": "pilotfish",
+        "policy_iteration": "subjective sizable wording"
+      },
+      "status": "error_during_execution",
+      "wall_seconds": 74.02,
+      "duration_ms": 70659,
+      "num_turns": 7,
+      "reported_cost_usd": 0.29687099999999994,
+      "tests_passed": null,
+      "tests_failed": null,
+      "agent_calls": [
+        {
+          "subagent_type": "scout",
+          "description": "Audit surface-a orchestration",
+          "run_in_background": true
+        },
+        {
+          "subagent_type": "scout",
+          "description": "Audit surface-b orchestration",
+          "run_in_background": true
+        }
+      ],
+      "model_usage": {
+        "claude-opus-4-8": {
+          "inputTokens": 6,
+          "outputTokens": 4399,
+          "cacheReadInputTokens": 47212,
+          "cacheCreationInputTokens": 14645,
+          "webSearchRequests": 0,
+          "costUSD": 0.280061,
+          "contextWindow": 1000000,
+          "maxOutputTokens": 64000
+        },
+        "claude-haiku-4-5-20251001": {
+          "inputTokens": 20,
+          "outputTokens": 746,
+          "cacheReadInputTokens": 0,
+          "cacheCreationInputTokens": 10448,
+          "webSearchRequests": 0,
+          "costUSD": 0.01681,
+          "contextWindow": 200000,
+          "maxOutputTokens": 32000
+        }
+      },
+      "raw_stream_sha256": "d915599c1b34429610e19040789b71affeb40626ad5a402392cc36843848c026",
+      "stop_reason": "Stopped after two background scouts proved that qualitative size wording was too ambiguous."
+    },
+    {
+      "id": "dispatch-brake-positive-control-research-remora-sized-gate-with-baton",
+      "source_pointer": "/interrupted_policy_probes/2",
+      "name": "research-remora-sized-gate-with-baton",
+      "configuration_identity": {
+        "fixture": "small-readonly-research",
+        "surface": "remora",
+        "policy_iteration": "sized read-only gate with auto-loaded baton-dispatch"
+      },
+      "status": "error_during_execution",
+      "wall_seconds": 137.09,
+      "duration_ms": 42964,
+      "num_turns": 20,
+      "reported_cost_usd": 0.79647,
+      "tests_passed": null,
+      "tests_failed": null,
+      "agent_calls": [
+        {
+          "subagent_type": "Explore",
+          "description": "稽核 surface-a 規則",
+          "run_in_background": true
+        },
+        {
+          "subagent_type": "Explore",
+          "description": "稽核 surface-b 規則",
+          "run_in_background": true
+        }
+      ],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "inputTokens": 46374,
+          "outputTokens": 3092,
+          "cacheReadInputTokens": 479744,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.549042,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        },
+        "gpt-5.6-luna": {
+          "inputTokens": 24542,
+          "outputTokens": 4702,
+          "cacheReadInputTokens": 14336,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.24742800000000004,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        }
+      },
+      "raw_stream_sha256": "3f16c74b56292f0f2f384537622cabdea82508a3fcf0444486c0f38b8006d90d",
+      "stop_reason": "Stopped after two background Explore calls selected by the auto-loaded baton-dispatch skill. The probe did not continue through main-session Plan synthesis, user approval, execution, or verification."
+    },
+    {
+      "id": "dispatch-brake-positive-control-research-remora-precedence-probe-unshipped",
+      "source_pointer": "/interrupted_policy_probes/3",
+      "name": "research-remora-precedence-probe-unshipped",
+      "configuration_identity": {
+        "fixture": "small-readonly-research",
+        "surface": "remora",
+        "policy_iteration": "unshipped generic-skill precedence wording"
+      },
+      "status": "error_during_execution",
+      "wall_seconds": null,
+      "duration_ms": 33177,
+      "num_turns": 8,
+      "reported_cost_usd": 0.8063840000000001,
+      "tests_passed": null,
+      "tests_failed": null,
+      "agent_calls": [
+        {
+          "subagent_type": "scout",
+          "description": "稽核 surface-a 規則",
+          "run_in_background": true
+        },
+        {
+          "subagent_type": "scout",
+          "description": "稽核 surface-b 規則",
+          "run_in_background": true
+        }
+      ],
+      "model_usage": {
+        "gpt-5.6-sol": {
+          "inputTokens": 57460,
+          "outputTokens": 2914,
+          "cacheReadInputTokens": 391168,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.555734,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        },
+        "gpt-5.6-luna": {
+          "inputTokens": 18435,
+          "outputTokens": 6083,
+          "cacheReadInputTokens": 12800,
+          "cacheCreationInputTokens": 0,
+          "webSearchRequests": 0,
+          "costUSD": 0.25065000000000004,
+          "contextWindow": 372000,
+          "maxOutputTokens": 32000
+        }
+      },
+      "raw_stream_sha256": "084bcdfa3b2597a7e0526d53db05c24a771958c8727ed9720f19348e846495da",
+      "stop_reason": "Stopped after two background scouts. The probe recorded the discovery decomposition but did not continue through main-session Plan synthesis, user approval, execution, or verification."
+    }
+  ],
+  "not_run": []
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -3117,6 +3117,264 @@ class PolicyContractTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             validate(replaced_cost)
 
+    def test_dispatch_brake_positive_control_attempts_are_source_bound(self) -> None:
+        gate = ROOT / "benchmarks" / "dispatch-brake" / "positive-controls"
+        attempts = json.loads(
+            (gate / "attempts.json").read_text(encoding="utf-8"),
+            parse_float=Decimal,
+        )
+        source_bytes = (gate / "results.json").read_bytes()
+        source = json.loads(source_bytes, parse_float=Decimal)
+        expected_source_keys = {
+            "schema_version",
+            "run_date",
+            "timezone",
+            "environment_reference",
+            "metric_note",
+            "complete_runs",
+            "interrupted_policy_probes",
+            "comparisons",
+        }
+        expected_complete_names = [
+            "research-pilotfish-hard-brake",
+            "research-remora-hard-brake",
+            "mechanical-pilotfish-hard-brake",
+            "mechanical-remora-hard-brake",
+            "research-pilotfish-broad-net-benefit",
+            "mechanical-pilotfish-balanced",
+            "negative-pilotfish-balanced",
+            "negative-remora-balanced",
+            "research-pilotfish-sized-gate",
+        ]
+        expected_interrupted_names = [
+            "negative-remora-broad-net-benefit",
+            "research-pilotfish-size-wording-rejected",
+            "research-remora-sized-gate-with-baton",
+            "research-remora-precedence-probe-unshipped",
+        ]
+        expected_passed_names = [
+            name
+            for name in expected_complete_names
+            if name != "research-remora-hard-brake"
+        ]
+        expected_failed_names = [
+            "research-remora-hard-brake",
+            *expected_interrupted_names,
+        ]
+        expected_invocation_pointers = [
+            *(f"/complete_runs/{index}" for index in range(9)),
+            *(f"/interrupted_policy_probes/{index}" for index in range(4)),
+        ]
+        expected_passed_pointers = [
+            f"/complete_runs/{index}"
+            for index in range(9)
+            if index != 1
+        ]
+        expected_failed_pointers = [
+            "/complete_runs/1",
+            *(f"/interrupted_policy_probes/{index}" for index in range(4)),
+        ]
+        expected_ledger_keys = {
+            "schema_version",
+            "source",
+            "counts",
+            "coverage",
+            "passed_attempts",
+            "failed_attempts",
+            "not_run",
+        }
+
+        def resolve(pointer: str) -> dict:
+            self.assertTrue(pointer.startswith("/"))
+            self.assertNotEqual(pointer, "/")
+            value: object = source
+            for token in pointer[1:].split("/"):
+                if isinstance(value, dict):
+                    self.assertIn(token, value)
+                    value = value[token]
+                elif isinstance(value, list):
+                    self.assertTrue(token.isdigit())
+                    index = int(token)
+                    self.assertLess(index, len(value))
+                    value = value[index]
+                else:
+                    self.fail(f"cannot resolve {pointer!r}")
+            self.assertIsInstance(value, dict)
+            return value
+
+        def expected_entry(pointer: str, run: dict) -> dict:
+            entry = {
+                "id": f"dispatch-brake-positive-control-{run['name']}",
+                "source_pointer": pointer,
+                "name": run["name"],
+                "configuration_identity": {
+                    key: run[key]
+                    for key in ("fixture", "surface", "policy_iteration")
+                },
+            }
+            entry.update(
+                {
+                    key: value
+                    for key, value in run.items()
+                    if key
+                    not in {"name", "fixture", "surface", "policy_iteration"}
+                }
+            )
+            return entry
+
+        def validate(ledger: dict) -> None:
+            self.assertEqual(set(ledger), expected_ledger_keys)
+            self.assertEqual(set(source), expected_source_keys)
+            self.assertEqual(source["schema_version"], 1)
+            self.assertEqual(source["run_date"], "2026-07-13")
+            self.assertEqual(source["timezone"], "Asia/Taipei")
+            self.assertEqual(
+                source["environment_reference"],
+                "../results.json",
+            )
+            self.assertIsInstance(source["metric_note"], str)
+            self.assertIsInstance(source["comparisons"], dict)
+            self.assertEqual(len(source["complete_runs"]), 9)
+            self.assertEqual(len(source["interrupted_policy_probes"]), 4)
+            self.assertEqual(
+                [run["name"] for run in source["complete_runs"]],
+                expected_complete_names,
+            )
+            self.assertEqual(
+                [run["name"] for run in source["interrupted_policy_probes"]],
+                expected_interrupted_names,
+            )
+            self.assertEqual(ledger["schema_version"], 1)
+            self.assertEqual(
+                ledger["source"],
+                {
+                    "path": "results.json",
+                    "sha256": hashlib.sha256(source_bytes).hexdigest(),
+                },
+            )
+            self.assertEqual(
+                ledger["coverage"],
+                {
+                    "source_pointers": [
+                        "/complete_runs",
+                        "/interrupted_policy_probes",
+                    ],
+                    "invocation_pointers": expected_invocation_pointers,
+                },
+            )
+
+            passed = ledger["passed_attempts"]
+            failed = ledger["failed_attempts"]
+            not_run = ledger["not_run"]
+            self.assertEqual(len(passed), 8)
+            self.assertEqual(len(failed), 5)
+            self.assertEqual(not_run, [])
+            self.assertEqual(
+                ledger["counts"],
+                {"attempted": 13, "passed": 8, "failed": 5},
+            )
+            self.assertEqual(
+                ledger["counts"]["attempted"], len(passed) + len(failed)
+            )
+            self.assertEqual(
+                ledger["counts"]["attempted"],
+                ledger["counts"]["passed"] + ledger["counts"]["failed"],
+            )
+            self.assertEqual(
+                [entry["name"] for entry in passed], expected_passed_names
+            )
+            self.assertEqual(
+                [entry["name"] for entry in failed], expected_failed_names
+            )
+            self.assertEqual(
+                [entry["source_pointer"] for entry in passed],
+                expected_passed_pointers,
+            )
+            self.assertEqual(
+                [entry["source_pointer"] for entry in failed],
+                expected_failed_pointers,
+            )
+
+            all_attempts = passed + failed
+            all_pointers = [entry["source_pointer"] for entry in all_attempts]
+            self.assertEqual(len(all_attempts), 13)
+            self.assertEqual(len({entry["id"] for entry in all_attempts}), 13)
+            self.assertEqual(len(set(all_pointers)), 13)
+            self.assertEqual(set(all_pointers), set(expected_invocation_pointers))
+            self.assertNotIn("/", all_pointers)
+            self.assertNotIn("/comparisons", all_pointers)
+
+            source_agent_call_count = sum(
+                len(run["agent_calls"])
+                for section in ("complete_runs", "interrupted_policy_probes")
+                for run in source[section]
+            )
+            self.assertEqual(
+                sum(len(entry["agent_calls"]) for entry in all_attempts),
+                source_agent_call_count,
+            )
+            self.assertGreater(source_agent_call_count, len(all_attempts))
+
+            for entry in all_attempts:
+                pointer = entry["source_pointer"]
+                run = resolve(pointer)
+                self.assertEqual(entry, expected_entry(pointer, run))
+                self.assertRegex(
+                    entry["raw_stream_sha256"],
+                    r"^[0-9a-f]{64}$",
+                )
+
+            self.assertEqual(failed[0]["status"], "error_max_budget_usd")
+            self.assertEqual(failed[0]["tests_passed"], 1)
+            self.assertEqual(failed[0]["tests_failed"], 0)
+            for entry in failed[1:]:
+                self.assertEqual(entry["status"], "error_during_execution")
+                self.assertIsNone(entry["tests_passed"])
+                self.assertIsNone(entry["tests_failed"])
+
+        validate(attempts)
+
+        missing_success = deepcopy(attempts)
+        missing_success["passed_attempts"].pop()
+        with self.assertRaises(AssertionError):
+            validate(missing_success)
+
+        missing_interrupted = deepcopy(attempts)
+        missing_interrupted["failed_attempts"].pop()
+        with self.assertRaises(AssertionError):
+            validate(missing_interrupted)
+
+        for invalid_pointer in ("/", "/comparisons"):
+            invalid_pointer_ledger = deepcopy(attempts)
+            aggregate_attempt = deepcopy(attempts["passed_attempts"][0])
+            aggregate_attempt["id"] = f"aggregate-{invalid_pointer}"
+            aggregate_attempt["source_pointer"] = invalid_pointer
+            invalid_pointer_ledger["passed_attempts"].append(aggregate_attempt)
+            invalid_pointer_ledger["counts"]["attempted"] += 1
+            invalid_pointer_ledger["counts"]["passed"] += 1
+            with self.assertRaises(AssertionError):
+                validate(invalid_pointer_ledger)
+
+        flipped_budget_status = deepcopy(attempts)
+        flipped_budget_status["failed_attempts"][0]["status"] = "success"
+        with self.assertRaises(AssertionError):
+            validate(flipped_budget_status)
+
+        replaced_stop_reason = deepcopy(attempts)
+        replaced_stop_reason["failed_attempts"][1]["stop_reason"] = "different"
+        with self.assertRaises(AssertionError):
+            validate(replaced_stop_reason)
+
+        replaced_hash = deepcopy(attempts)
+        replaced_hash["passed_attempts"][0]["raw_stream_sha256"] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(replaced_hash)
+
+        replaced_cost = deepcopy(attempts)
+        replaced_cost["passed_attempts"][0]["reported_cost_usd"] = Decimal("0")
+        with self.assertRaises(AssertionError):
+            validate(replaced_cost)
+
     def test_installer_requires_tool_enforcing_runtime(self) -> None:
         installer = (ROOT / "install/AGENT-INSTALL.md").read_text(encoding="utf-8")
         self.assertIn("claude --version", installer)


### PR DESCRIPTION
## Summary

- add a source-bound canonical sidecar for all 13 dispatch-brake positive-control attempts
- record eight successful completed runs and five terminal failures
- keep the budget-exhausted run failed despite passing fixture tests
- preserve null tests and stop reasons for four deliberately interrupted probes
- bind every attempt to configuration, metrics, reported cost, Agent calls, model usage, and raw-stream evidence
- keep comparisons and child Agent calls outside attempt accounting

## Verification

- focused positive-control attempt contract
- full repository suite: 75/75
- renderer and diff checks
- duplicate-key validation
- fresh outcome verifier: CONFIRMED

This is the fourth vertical slice of #65 and does not close the issue.

Refs #65