### PR TITLE
feat(benchmarks): bind Baton dispatch-effect attempts

### DIFF
--- a/benchmarks/baton-dispatch-effect/attempts.json
+++ b/benchmarks/baton-dispatch-effect/attempts.json
@@ -1,0 +1,232 @@
+{
+  "schema_version": 1,
+  "source": {
+    "path": "results.json",
+    "sha256": "d5ef8cef7956cb0a0cdf84582f900c130ebfef32228fc1fb3e9fa91d9fdce713"
+  },
+  "counts": {
+    "attempted": 7,
+    "passed": 4,
+    "failed": 3
+  },
+  "coverage": {
+    "source_pointers": [
+      "/small_availability_observation/cells",
+      "/large_policy_activation_gate/attempts",
+      "/release_payload_replay"
+    ],
+    "invocation_pointers": [
+      "/small_availability_observation/cells/0",
+      "/small_availability_observation/cells/1",
+      "/large_policy_activation_gate/attempts/0",
+      "/large_policy_activation_gate/attempts/1",
+      "/large_policy_activation_gate/attempts/2",
+      "/large_policy_activation_gate/attempts/3",
+      "/release_payload_replay"
+    ]
+  },
+  "passed_attempts": [
+    {
+      "id": "baton-dispatch-effect-small-control",
+      "source_pointer": "/small_availability_observation/cells/0",
+      "class": "availability",
+      "configuration_identity": {
+        "client_version": "2.1.217",
+        "fixture": "../dispatch-brake/positive-controls/research/fixture",
+        "fixture_digest": "8c90ca5b673272f3e954e535d3c7c88417e888f27e30a4dfda25b8675621ede8",
+        "policy_sha256": "7ff86564cd4cd8469cf3d24646fd395c57be09dc1fc7e1efa9d0d77c61ecfb21",
+        "prompt_file_sha256": "720d5727022137dfd17a99049e70c19158618a9182b2a2d591b1c169670f2241",
+        "prompt_runtime_input_sha256": "26e16f5047b91205f8d0dec72116891475ad3e25be3b3aba00d1ca40927bd23c",
+        "baton_visibility": "absent"
+      },
+      "status": "correctness_pass",
+      "boundary": "Availability observation only. The fixture itself contains orchestration material, so this ordered pair is not presented as a cue-free causal A/B experiment.",
+      "wall_seconds": 129.27,
+      "duration_ms": 127731,
+      "duration_api_ms": 128484,
+      "num_turns": 14,
+      "client_reported_cost_usd": 0.718764,
+      "baton_listed_at_init": false,
+      "baton_skill_call_count": 0,
+      "agent_call_count": 0,
+      "topology": "direct main-session execution",
+      "test_passed": true,
+      "report_sha256": "1521654b737d7064bc6ca120cd00d1f4b1d3c8f22e634cfbccd6ed7efd260262",
+      "raw_stream_sha256": "451fca5f9eb2ed0b70a06fffbc3d697b7987fa19f2491cc6391e1601393171a8"
+    },
+    {
+      "id": "baton-dispatch-effect-small-treatment",
+      "source_pointer": "/small_availability_observation/cells/1",
+      "class": "availability",
+      "configuration_identity": {
+        "client_version": "2.1.217",
+        "fixture": "../dispatch-brake/positive-controls/research/fixture",
+        "fixture_digest": "8c90ca5b673272f3e954e535d3c7c88417e888f27e30a4dfda25b8675621ede8",
+        "policy_sha256": "7ff86564cd4cd8469cf3d24646fd395c57be09dc1fc7e1efa9d0d77c61ecfb21",
+        "prompt_file_sha256": "720d5727022137dfd17a99049e70c19158618a9182b2a2d591b1c169670f2241",
+        "prompt_runtime_input_sha256": "26e16f5047b91205f8d0dec72116891475ad3e25be3b3aba00d1ca40927bd23c",
+        "baton_visibility": "project skill"
+      },
+      "status": "correctness_pass_no_activation",
+      "boundary": "Availability observation only. The fixture itself contains orchestration material, so this ordered pair is not presented as a cue-free causal A/B experiment.",
+      "wall_seconds": 130.17,
+      "duration_ms": 128324,
+      "duration_api_ms": 130704,
+      "num_turns": 14,
+      "client_reported_cost_usd": 0.741686,
+      "baton_listed_at_init": true,
+      "baton_skill_call_count": 0,
+      "agent_call_count": 0,
+      "topology": "direct main-session execution",
+      "test_passed": true,
+      "report_sha256": "7c8bf3b458c6d1b2c6d0df12e62d16e076585da15b01045d87e1ff31583df800",
+      "raw_stream_sha256": "fcbab2ee80c39dce11725d150b1d1d668669bb665bfc8373cacaade591298e05"
+    },
+    {
+      "id": "baton-dispatch-effect-large-v131-4",
+      "source_pointer": "/large_policy_activation_gate/attempts/3",
+      "class": "activation",
+      "configuration_identity": {
+        "fixture_baseline_commit": "34ebabe2a26dd53de1a019607992f1ac10af245f",
+        "fixture_baseline_tree": "3773149bae5c514abe6d141d6fc5216e86d02574",
+        "prompt_file_sha256": "c0cebdcebe1186f41bed2ff442bd35bf3df68719530c1f4555f8b609d735ffba",
+        "prompt_runtime_input_sha256": "246a68b72299d8b4cd56871cebd9297cc5748c7e21b77154cadaecb3530f97ae",
+        "client_version": "2.1.218",
+        "policy_sha256": "17d272b6ddd6d95a749a802f5e29dfd4625c884f8a84bf817ffc20bfca6b39bf"
+      },
+      "status": "passed_activation_dispatch_ownership_collection_correctness",
+      "boundary": "The cue scan applies to the user prompt only. The four-domain fixture contains orchestration material, so this Gate establishes prompt-neutral reachability rather than a fully cue-free or causal experiment.",
+      "wall_seconds": 400.0,
+      "client_reported_cost_usd": 1.8456953000000003,
+      "baton_skill_call_count": 1,
+      "agent_call_count": 4,
+      "completed_agent_count": 4,
+      "test_passed": true,
+      "raw_stream_sha256": "0912e5a2a40e5dba5a2ce439b92020e5d84e7b2a858489744ec96e0a5badb313",
+      "active_scope_overlap_observed": false,
+      "audit_sha256": "1a23459cb28d91683320d10d17d77617861ece407fcd2b6b3e472d5e19484969",
+      "terminal_is_error": false,
+      "final_byte_verification": {
+        "verification_recorded_at_utc": "2026-07-23T02:01:06Z",
+        "command": "npm test",
+        "exit_code": 0,
+        "test_output": "AUDIT.md covers all four domains with file:line evidence",
+        "audit_sha256": "1a23459cb28d91683320d10d17d77617861ece407fcd2b6b3e472d5e19484969",
+        "only_change": "?? AUDIT.md"
+      }
+    },
+    {
+      "id": "baton-dispatch-effect-large-v131-release-payload-replay",
+      "source_pointer": "/release_payload_replay",
+      "class": "replay",
+      "configuration_identity": {
+        "fixture_baseline_commit": "34ebabe2a26dd53de1a019607992f1ac10af245f",
+        "fixture_baseline_tree": "3773149bae5c514abe6d141d6fc5216e86d02574",
+        "prompt_file_sha256": "c0cebdcebe1186f41bed2ff442bd35bf3df68719530c1f4555f8b609d735ffba",
+        "prompt_runtime_input_sha256": "246a68b72299d8b4cd56871cebd9297cc5748c7e21b77154cadaecb3530f97ae",
+        "client_version": "2.1.218",
+        "policy_sha256": "17d272b6ddd6d95a749a802f5e29dfd4625c884f8a84bf817ffc20bfca6b39bf",
+        "agents_json_sha256": "0b42c137daf4006a9c85b201c9434e13640fce69fb10fcf0fba6ba2b1379723c",
+        "baton_skill_sha256": "48b1e573a9e3de85fdb68c433bd47d69add9ec8491613ca304cfcef2326e3d67"
+      },
+      "status": "passed_activation_dispatch_ownership_collection_final_byte_correctness",
+      "boundary": "The cue scan applies to the user prompt only. The committed fixture contains orchestration material, so this replay is prompt-neutral reachability evidence rather than a fully cue-free or causal experiment.",
+      "duration_ms": 168156,
+      "duration_api_ms": 574306,
+      "num_turns": 4,
+      "client_reported_cost_usd": 1.6609133999999997,
+      "terminal_is_error": false,
+      "baton_skill_call_count": 1,
+      "agent_call_count": 4,
+      "completed_agent_count": 4,
+      "active_scope_overlap_observed": false,
+      "test_passed": true,
+      "audit_sha256": "92a111ddc624a41a8e3ab877aefdbc593db80a032dd637156fdf44a1854a617a",
+      "raw_stream_sha256": "d726ce891bdfb3ece2177c24d5cf20d4b27315137643dc47eddb0d7573e65693",
+      "final_byte_verification": {
+        "verification_recorded_at_utc": "2026-07-23T03:36:58Z",
+        "command": "npm test",
+        "exit_code": 0,
+        "test_output": "AUDIT.md covers all four domains with file:line evidence",
+        "audit_sha256": "92a111ddc624a41a8e3ab877aefdbc593db80a032dd637156fdf44a1854a617a",
+        "only_change": "?? AUDIT.md"
+      }
+    }
+  ],
+  "failed_attempts": [
+    {
+      "id": "baton-dispatch-effect-large-v131-1",
+      "source_pointer": "/large_policy_activation_gate/attempts/0",
+      "class": "activation",
+      "configuration_identity": {
+        "fixture_baseline_commit": "34ebabe2a26dd53de1a019607992f1ac10af245f",
+        "fixture_baseline_tree": "3773149bae5c514abe6d141d6fc5216e86d02574",
+        "prompt_file_sha256": "c0cebdcebe1186f41bed2ff442bd35bf3df68719530c1f4555f8b609d735ffba",
+        "prompt_runtime_input_sha256": "246a68b72299d8b4cd56871cebd9297cc5748c7e21b77154cadaecb3530f97ae",
+        "client_version": "2.1.217",
+        "policy_sha256": "46155d17c9d78c5fb567571ece0928e1515d04ea9ef98aaaaec5688a81e7b614"
+      },
+      "status": "activation_dispatch_pass_ownership_fail",
+      "boundary": "The cue scan applies to the user prompt only. The four-domain fixture contains orchestration material, so this Gate establishes prompt-neutral reachability rather than a fully cue-free or causal experiment.",
+      "wall_seconds": 499.4,
+      "client_reported_cost_usd": 3.5365311499999996,
+      "baton_skill_call_count": 1,
+      "agent_call_count": 2,
+      "completed_agent_count": 2,
+      "test_passed": true,
+      "raw_stream_sha256": "c9a275036928636ec0c1887ac718fc38744571caf1001b410e5e7aa5511266f0",
+      "failure": "main duplicated active domain-c and domain-d reconnaissance and interleaved main work between the two launches",
+      "audit_sha256": "cd23f8813592c83de39af32f5618a3be0b8c21ff4cad69403c44d7d14bbe0451"
+    },
+    {
+      "id": "baton-dispatch-effect-large-v131-2",
+      "source_pointer": "/large_policy_activation_gate/attempts/1",
+      "class": "activation",
+      "configuration_identity": {
+        "fixture_baseline_commit": "34ebabe2a26dd53de1a019607992f1ac10af245f",
+        "fixture_baseline_tree": "3773149bae5c514abe6d141d6fc5216e86d02574",
+        "prompt_file_sha256": "c0cebdcebe1186f41bed2ff442bd35bf3df68719530c1f4555f8b609d735ffba",
+        "prompt_runtime_input_sha256": "246a68b72299d8b4cd56871cebd9297cc5748c7e21b77154cadaecb3530f97ae",
+        "client_version": "2.1.217",
+        "policy_sha256": "153d30aa3032033f3a6368a0a77a6d37b43f2e4e9d97a5a8689c24d1472bdf6b"
+      },
+      "status": "activation_dispatch_parallel_launch_pass_ownership_fail",
+      "boundary": "The cue scan applies to the user prompt only. The four-domain fixture contains orchestration material, so this Gate establishes prompt-neutral reachability rather than a fully cue-free or causal experiment.",
+      "wall_seconds": 372.8,
+      "client_reported_cost_usd": 2.937291149999999,
+      "baton_skill_call_count": 1,
+      "agent_call_count": 2,
+      "completed_agent_count": 2,
+      "test_passed": true,
+      "raw_stream_sha256": "281aeef1943de2f0696afd6a0ff85234a53462ca1653ec80932403cf4a8e0f60",
+      "failure": "a mixed-scope main Bash command read active agent-owned domain-c/VERSION",
+      "audit_sha256": "1abe081a1022374d96c375832523eecb5f0df8924ac9803162f22719b813202c"
+    },
+    {
+      "id": "baton-dispatch-effect-large-v131-3",
+      "source_pointer": "/large_policy_activation_gate/attempts/2",
+      "class": "activation",
+      "configuration_identity": {
+        "fixture_baseline_commit": "34ebabe2a26dd53de1a019607992f1ac10af245f",
+        "fixture_baseline_tree": "3773149bae5c514abe6d141d6fc5216e86d02574",
+        "prompt_file_sha256": "c0cebdcebe1186f41bed2ff442bd35bf3df68719530c1f4555f8b609d735ffba",
+        "prompt_runtime_input_sha256": "246a68b72299d8b4cd56871cebd9297cc5748c7e21b77154cadaecb3530f97ae",
+        "client_version": "2.1.217",
+        "policy_sha256": "17d272b6ddd6d95a749a802f5e29dfd4625c884f8a84bf817ffc20bfca6b39bf"
+      },
+      "status": "topology_pass_runtime_limit_outcome_incomplete",
+      "boundary": "The cue scan applies to the user prompt only. The four-domain fixture contains orchestration material, so this Gate establishes prompt-neutral reachability rather than a fully cue-free or causal experiment.",
+      "wall_seconds": 177.16,
+      "client_reported_cost_usd": 0.9987456499999999,
+      "baton_skill_call_count": 1,
+      "agent_call_count": 4,
+      "completed_agent_count": 2,
+      "test_passed": false,
+      "raw_stream_sha256": "f7315489c29509dc31f8a5403a50ba28c1e84966a5ccb74bd8aca222fed4c8ed",
+      "failed_agent_count": 2,
+      "active_scope_overlap_observed": false,
+      "failure": "two scouts hit the Opus session limit; no AUDIT.md was produced"
+    }
+  ],
+  "not_run": []
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -449,6 +449,330 @@ class PolicyContractTests(unittest.TestCase):
             self.assertIn("0.1.1", content)
             self.assertIn("results.json", content)
 
+    def test_baton_dispatch_effect_attempts_are_source_bound(self) -> None:
+        benchmark = ROOT / "benchmarks" / "baton-dispatch-effect"
+        ledger = json.loads(
+            (benchmark / "attempts.json").read_text(encoding="utf-8"),
+            parse_float=Decimal,
+        )
+        source_bytes = (benchmark / "results.json").read_bytes()
+        source = json.loads(source_bytes, parse_float=Decimal)
+        expected_source_keys = {
+            "schema_version",
+            "run_date",
+            "timezone",
+            "client",
+            "treatment_dependency",
+            "shared_runtime",
+            "small_availability_observation",
+            "large_policy_activation_gate",
+            "release_payload_replay",
+            "metric_note",
+        }
+        expected_pointers = [
+            "/small_availability_observation/cells/0",
+            "/small_availability_observation/cells/1",
+            "/large_policy_activation_gate/attempts/0",
+            "/large_policy_activation_gate/attempts/1",
+            "/large_policy_activation_gate/attempts/2",
+            "/large_policy_activation_gate/attempts/3",
+            "/release_payload_replay",
+        ]
+        passed_pointers = [
+            expected_pointers[0],
+            expected_pointers[1],
+            expected_pointers[5],
+            expected_pointers[6],
+        ]
+        failed_pointers = expected_pointers[2:5]
+        ledger_keys = {
+            "schema_version",
+            "source",
+            "counts",
+            "coverage",
+            "passed_attempts",
+            "failed_attempts",
+            "not_run",
+        }
+
+        def resolve(pointer: str) -> dict:
+            value: object = source
+            for token in pointer.removeprefix("/").split("/"):
+                if isinstance(value, dict):
+                    self.assertIn(token, value)
+                    value = value[token]
+                elif isinstance(value, list):
+                    self.assertTrue(token.isdigit())
+                    value = value[int(token)]
+                else:
+                    self.fail(f"cannot resolve {pointer!r}")
+            self.assertIsInstance(value, dict)
+            return value
+
+        def project(pointer: str) -> dict:
+            record = resolve(pointer)
+            if pointer.startswith("/small_availability_observation/cells/"):
+                parent = source["small_availability_observation"]
+                return {
+                    "id": f"baton-dispatch-effect-small-{record['name']}",
+                    "source_pointer": pointer,
+                    "class": "availability",
+                    "configuration_identity": {
+                        "client_version": parent["client_version"],
+                        "fixture": parent["fixture"],
+                        "fixture_digest": parent["fixture_digest"],
+                        "policy_sha256": parent["policy_sha256"],
+                        "prompt_file_sha256": parent["prompt_file_sha256"],
+                        "prompt_runtime_input_sha256": parent[
+                            "prompt_runtime_input_sha256"
+                        ],
+                        "baton_visibility": record["baton_visibility"],
+                    },
+                    "status": record["status"],
+                    "boundary": parent["claim_boundary"],
+                    **{
+                        key: record[key]
+                        for key in (
+                            "wall_seconds",
+                            "duration_ms",
+                            "duration_api_ms",
+                            "num_turns",
+                            "client_reported_cost_usd",
+                            "baton_listed_at_init",
+                            "baton_skill_call_count",
+                            "agent_call_count",
+                            "topology",
+                            "test_passed",
+                            "report_sha256",
+                            "raw_stream_sha256",
+                        )
+                    },
+                }
+            if pointer.startswith("/large_policy_activation_gate/attempts/"):
+                parent = source["large_policy_activation_gate"]
+                entry = {
+                    "id": f"baton-dispatch-effect-{record['name']}",
+                    "source_pointer": pointer,
+                    "class": "activation",
+                    "configuration_identity": {
+                        "fixture_baseline_commit": parent["fixture"][
+                            "baseline_commit"
+                        ],
+                        "fixture_baseline_tree": parent["fixture"]["baseline_tree"],
+                        "prompt_file_sha256": parent["prompt_file_sha256"],
+                        "prompt_runtime_input_sha256": parent[
+                            "prompt_runtime_input_sha256"
+                        ],
+                        "client_version": record["client_version"],
+                        "policy_sha256": record["policy_sha256"],
+                    },
+                    "status": record["status"],
+                    "boundary": parent["claim_boundary"],
+                    **{
+                        key: record[key]
+                        for key in (
+                            "wall_seconds",
+                            "client_reported_cost_usd",
+                            "baton_skill_call_count",
+                            "agent_call_count",
+                            "completed_agent_count",
+                            "test_passed",
+                            "raw_stream_sha256",
+                        )
+                    },
+                }
+                for key in (
+                    "failed_agent_count",
+                    "active_scope_overlap_observed",
+                    "failure",
+                    "audit_sha256",
+                    "terminal_is_error",
+                ):
+                    if key in record:
+                        entry[key] = record[key]
+                if "post_run_verification" in record:
+                    entry["final_byte_verification"] = record[
+                        "post_run_verification"
+                    ]
+                return entry
+
+            self.assertEqual(pointer, "/release_payload_replay")
+            return {
+                "id": "baton-dispatch-effect-large-v131-release-payload-replay",
+                "source_pointer": pointer,
+                "class": "replay",
+                "configuration_identity": {
+                    key: record[key]
+                    for key in (
+                        "fixture_baseline_commit",
+                        "fixture_baseline_tree",
+                        "prompt_file_sha256",
+                        "prompt_runtime_input_sha256",
+                        "client_version",
+                        "policy_sha256",
+                        "agents_json_sha256",
+                        "baton_skill_sha256",
+                    )
+                },
+                "status": record["status"],
+                "boundary": record["claim_boundary"],
+                **{
+                    key: record[key]
+                    for key in (
+                        "duration_ms",
+                        "duration_api_ms",
+                        "num_turns",
+                        "client_reported_cost_usd",
+                        "terminal_is_error",
+                        "baton_skill_call_count",
+                        "agent_call_count",
+                        "completed_agent_count",
+                        "active_scope_overlap_observed",
+                        "test_passed",
+                        "audit_sha256",
+                        "raw_stream_sha256",
+                    )
+                },
+                "final_byte_verification": record["post_run_verification"],
+            }
+
+        def validate(candidate: dict) -> None:
+            self.assertEqual(set(source), expected_source_keys)
+            self.assertEqual(source["schema_version"], 3)
+            self.assertEqual(
+                [
+                    cell["name"]
+                    for cell in source["small_availability_observation"]["cells"]
+                ],
+                ["control", "treatment"],
+            )
+            self.assertEqual(
+                [
+                    attempt["name"]
+                    for attempt in source["large_policy_activation_gate"][
+                        "attempts"
+                    ]
+                ],
+                [f"large-v131-{number}" for number in range(1, 5)],
+            )
+            self.assertEqual(
+                source["release_payload_replay"]["name"],
+                "large-v131-release-payload-replay",
+            )
+            self.assertEqual(set(candidate), ledger_keys)
+            self.assertEqual(candidate["schema_version"], 1)
+            self.assertEqual(
+                candidate["source"],
+                {
+                    "path": "results.json",
+                    "sha256": hashlib.sha256(source_bytes).hexdigest(),
+                },
+            )
+            self.assertEqual(
+                candidate["coverage"],
+                {
+                    "source_pointers": [
+                        "/small_availability_observation/cells",
+                        "/large_policy_activation_gate/attempts",
+                        "/release_payload_replay",
+                    ],
+                    "invocation_pointers": expected_pointers,
+                },
+            )
+            passed = candidate["passed_attempts"]
+            failed = candidate["failed_attempts"]
+            self.assertEqual(candidate["not_run"], [])
+            self.assertEqual(
+                candidate["counts"], {"attempted": 7, "passed": 4, "failed": 3}
+            )
+            self.assertEqual(len(passed), 4)
+            self.assertEqual(len(failed), 3)
+            self.assertEqual(
+                [entry["source_pointer"] for entry in passed], passed_pointers
+            )
+            self.assertEqual(
+                [entry["source_pointer"] for entry in failed], failed_pointers
+            )
+            entries = passed + failed
+            self.assertEqual(len({entry["id"] for entry in entries}), 7)
+            self.assertEqual(
+                len({entry["source_pointer"] for entry in entries}), 7
+            )
+            self.assertEqual(
+                {entry["source_pointer"] for entry in entries},
+                set(expected_pointers),
+            )
+            for entry in entries:
+                self.assertEqual(entry, project(entry["source_pointer"]))
+                self.assertRegex(entry["raw_stream_sha256"], r"^[0-9a-f]{64}$")
+            self.assertTrue(failed[0]["status"].endswith("ownership_fail"))
+            self.assertTrue(failed[1]["status"].endswith("ownership_fail"))
+            self.assertTrue(failed[0]["test_passed"])
+            self.assertTrue(failed[1]["test_passed"])
+            self.assertEqual(
+                failed[2]["status"],
+                "topology_pass_runtime_limit_outcome_incomplete",
+            )
+            self.assertFalse(failed[2]["test_passed"])
+            self.assertEqual(passed[2]["final_byte_verification"]["exit_code"], 0)
+            self.assertEqual(passed[3]["class"], "replay")
+            child_calls = sum(entry["agent_call_count"] for entry in entries)
+            self.assertEqual(child_calls, 16)
+            self.assertGreater(child_calls, candidate["counts"]["attempted"])
+            for forbidden in (
+                "/small_availability_observation/gate",
+                "/large_policy_activation_gate/effect_gate",
+                "/large_policy_activation_gate/attempts/3/post_run_verification",
+                "/release_payload_replay/effect_gate",
+            ):
+                self.assertNotIn(
+                    forbidden, candidate["coverage"]["invocation_pointers"]
+                )
+
+        validate(ledger)
+
+        missing = deepcopy(ledger)
+        missing["passed_attempts"].pop()
+        with self.assertRaises(AssertionError):
+            validate(missing)
+
+        for invalid_pointer in (
+            "/large_policy_activation_gate/effect_gate",
+            "/large_policy_activation_gate/attempts/3/post_run_verification",
+        ):
+            inserted = deepcopy(ledger)
+            inserted["passed_attempts"][0]["source_pointer"] = invalid_pointer
+            with self.assertRaises(AssertionError):
+                validate(inserted)
+
+        for index in (0, 1):
+            flipped = deepcopy(ledger)
+            flipped["failed_attempts"][index]["status"] = "passed"
+            with self.assertRaises(AssertionError):
+                validate(flipped)
+
+        for key, value in (
+            ("failure", "different"),
+            ("raw_stream_sha256", "0" * 64),
+            ("client_reported_cost_usd", Decimal("0")),
+        ):
+            replaced = deepcopy(ledger)
+            replaced["failed_attempts"][0][key] = value
+            with self.assertRaises(AssertionError):
+                validate(replaced)
+
+        replaced_identity = deepcopy(ledger)
+        replaced_identity["failed_attempts"][0]["configuration_identity"][
+            "policy_sha256"
+        ] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(replaced_identity)
+
+        child_inflated = deepcopy(ledger)
+        child_inflated["counts"] = {"attempted": 16, "passed": 14, "failed": 2}
+        with self.assertRaises(AssertionError):
+            validate(child_inflated)
+
     def test_spontaneous_dispatch_inputs_are_cue_free_and_recorded(self) -> None:
         benchmark = ROOT / "benchmarks" / "spontaneous-dispatch"
         results = json.loads((benchmark / "results.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- add a SHA-bound, source-native sidecar for the seven top-level Baton dispatch-effect sessions
- record 4 passes and retain 3 ownership/runtime failures with candidate identity and exact boundaries
- keep aggregate gates, nested verification records, and 16 child Agent calls outside attempt accounting
- add source-specific drift and tamper checks without modifying historical results

This deliberately excludes `baton-compatibility`, whose invocation/resume/probe/summary mixture needs a separate contract to avoid recreating the no-go universal ledger from #70.

## Verification

- focused attempt-accounting contract
- full repository suite: 76/76
- renderer `--check`
- strict JSON duplicate-key parse
- source SHA-256 unchanged: `d5ef8cef7956cb0a0cdf84582f900c130ebfef32228fc1fb3e9fa91d9fdce713`
- exact two-path scope and `git diff --check`
- fresh outcome verifier: `CONFIRMED`

No live or paid gate was run. Part of #65.