### PR TITLE
feat(benchmarks): bind Baton compatibility attempts

### DIFF
--- a/benchmarks/baton-compatibility/attempts.json
+++ b/benchmarks/baton-compatibility/attempts.json
@@ -1,0 +1,983 @@
+{
+  "schema_version": 1,
+  "source": {
+    "path": "results.json",
+    "sha256": "fd4c9271035f3f43aad8f7b51b69a831e7a62709c2d255a9c987b040308ac170"
+  },
+  "counts": {
+    "attempted": 15,
+    "passed": 10,
+    "failed": 5,
+    "unknown_invocation_count_records": 4
+  },
+  "coverage": {
+    "invocation_pointers": [
+      "/previous_final_gate/turns/0",
+      "/previous_final_gate/turns/1",
+      "/final_gate/turns/0",
+      "/final_gate/turns/1",
+      "/v1_3_2_release_gate/turns/0",
+      "/v1_3_2_release_gate/turns/1",
+      "/v1_3_2_opus5_release_gate/turns/0",
+      "/v1_3_2_opus5_release_gate/turns/1",
+      "/v1_3_2_opus5_release_gate/turns/2",
+      "/v1_3_2_opus5_rejected_user_source_attempt/turn_1",
+      "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe",
+      "/failed_candidate_gate/turns/0",
+      "/superseded_candidate_gate/turns/0",
+      "/superseded_candidate_gate/turns/1",
+      "/superseded_candidate_gate/turns/2"
+    ],
+    "unknown_invocation_count_pointers": [
+      "/previous_release_gate",
+      "/historical_release_gate",
+      "/superseded_gate",
+      "/rejected_harness_run"
+    ],
+    "excluded_summary_pointers": [
+      "/v1_3_2_post_gate_role_change",
+      "/unexercised_controls",
+      "/post_gate_role_frontmatter_change"
+    ]
+  },
+  "passed_attempts": [
+    {
+      "id": "baton-compatibility-previous-final-turn-1",
+      "source_pointer": "/previous_final_gate/turns/0",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/previous_final_gate",
+        "status": "passed",
+        "source_base_head": "a38dd2dde000441b24881fa49495e545ff21b9e6",
+        "release_candidate_version": "1.3.0",
+        "fast_mode": false,
+        "transcript_sha256": "98724de501d714dcb58b315b2260147f9cdd43975f16e52297a84ed258a83ac4",
+        "passed": true
+      },
+      "status": "passed_phase",
+      "boundary": "The passed gate records this discovery and approval invocation as completed.",
+      "record": {
+        "cli_invocation": 1,
+        "prompt_turn": "turn-1",
+        "prompt_file_sha256": "45dbe7b6b24cb5838ebf4219011797b61f172fcc18f0ca5039144017e93fcca7",
+        "prompt_runtime_input_sha256": "d2ad46b7ecfb503f8f7185d6d68f404d326f1a4a480b9141d1a80318a746bb73",
+        "max_budget_usd": 6,
+        "phase": "discovery_plan_approval_wait",
+        "disposition": "completed",
+        "duration_ms": 151241,
+        "duration_api_ms": 286044,
+        "num_turns": 2,
+        "client_reported_cost_usd": 2.07174695,
+        "models": [
+          "claude-fable-5",
+          "claude-haiku-4-5-20251001",
+          "claude-opus-4-8"
+        ],
+        "baton_loaded": true,
+        "discovery_topology": "two parallel background scouts",
+        "scout_calls": [
+          {
+            "label": "Scout A",
+            "role": "scout",
+            "background": true,
+            "invocation_model": null,
+            "observed_model": "claude-haiku-4-5-20251001",
+            "observed_tools": [
+              "Read"
+            ]
+          },
+          {
+            "label": "Scout B",
+            "role": "scout",
+            "background": true,
+            "invocation_model": null,
+            "observed_model": "claude-haiku-4-5-20251001",
+            "observed_tools": [
+              "Read",
+              "Glob"
+            ]
+          }
+        ],
+        "git_clean": true,
+        "writes_before_approval": false,
+        "plan_verifier_role": "plan-verifier",
+        "plan_verifier_invocation_model": null,
+        "plan_verifier_observed_model": "claude-opus-4-8",
+        "plan_verifier_observed_tools": [
+          "Read"
+        ],
+        "verifier_sequence": [
+          "READY"
+        ],
+        "plan_revision_applied": true,
+        "plan_revision_summary": "one non-blocking citation suggestion was adopted before the final Plan; readiness remained READY"
+      }
+    },
+    {
+      "id": "baton-compatibility-previous-final-turn-2",
+      "source_pointer": "/previous_final_gate/turns/1",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/previous_final_gate",
+        "status": "passed",
+        "source_base_head": "a38dd2dde000441b24881fa49495e545ff21b9e6",
+        "release_candidate_version": "1.3.0",
+        "fast_mode": false,
+        "transcript_sha256": "98724de501d714dcb58b315b2260147f9cdd43975f16e52297a84ed258a83ac4",
+        "passed": true
+      },
+      "status": "passed_phase",
+      "boundary": "The passed gate records this execution and verification invocation as completed.",
+      "record": {
+        "cli_invocation": 2,
+        "prompt_turn": "turn-2",
+        "prompt_file_sha256": "82d833090ba91982651de9ac4beed8fc96311119c6eb9c6f0304c292821918e7",
+        "prompt_runtime_input_sha256": "93ae95d1cd4eebca91ab42a06d484e180f46dd1f327e471a5a4fd2a27ca2f344",
+        "max_budget_usd": 6,
+        "phase": "approved_execution_verification",
+        "disposition": "completed",
+        "duration_ms": 172737,
+        "duration_api_ms": 172012,
+        "num_turns": 4,
+        "client_reported_cost_usd": 1.43709855,
+        "models": [
+          "claude-fable-5",
+          "claude-sonnet-5",
+          "claude-opus-4-8"
+        ],
+        "writer": "mech-executor",
+        "writer_invocation_model": null,
+        "writer_observed_model": "claude-sonnet-5",
+        "writer_observed_tools": [
+          "Write",
+          "Bash"
+        ],
+        "verifier": "verifier",
+        "verifier_invocation_model": null,
+        "verifier_observed_model": "claude-opus-4-8",
+        "verifier_observed_tools": [
+          "Bash",
+          "Read"
+        ],
+        "only_change": "?? REPORT.md",
+        "git_status": "?? REPORT.md",
+        "report_sha256": "f31e1ec69bc78dcb9e2c1aae7b5665c1da50490485fac69871a2d4848cbfb966",
+        "report_lines": 23,
+        "report_bytes": 6792,
+        "citation_count": 52,
+        "citation_surfaces": [
+          "surface-a/",
+          "surface-b/"
+        ],
+        "test_command": "npm test",
+        "test_passed": true,
+        "verifier_sequence": [
+          "CONFIRMED"
+        ],
+        "verifier_note": "One citation included architecture.md:63, a blank line; architecture.md:62 fully supported the claim. This was non-blocking and was not changed after CONFIRMED."
+      }
+    },
+    {
+      "id": "baton-compatibility-final-turn-1",
+      "source_pointer": "/final_gate/turns/0",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/final_gate",
+        "status": "passed",
+        "source_base_head": "4d65cc94b59acec2debec37983ad0a021440d643",
+        "release_candidate_version": "1.3.1",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-4-8",
+        "fast_mode": false,
+        "transcript_sha256": "6563b1c5f3d15f2640688a8509fa093364c5534f9246e0ee700e67c3469ac0b5",
+        "passed": true
+      },
+      "status": "passed_phase",
+      "boundary": "The passed gate records this discovery and approval invocation as completed.",
+      "record": {
+        "cli_invocation": 1,
+        "prompt_turn": "turn-1",
+        "prompt_file_sha256": "45dbe7b6b24cb5838ebf4219011797b61f172fcc18f0ca5039144017e93fcca7",
+        "prompt_runtime_input_sha256": "d2ad46b7ecfb503f8f7185d6d68f404d326f1a4a480b9141d1a80318a746bb73",
+        "max_budget_usd": 6,
+        "phase": "discovery_plan_approval_wait",
+        "disposition": "completed",
+        "wall_seconds": 168.41,
+        "duration_ms": 166668,
+        "duration_api_ms": 165928,
+        "num_turns": 8,
+        "client_reported_cost_usd": 1.104294,
+        "models": [
+          "claude-opus-4-8"
+        ],
+        "baton_loaded": true,
+        "discovery_topology": "direct main-session read; Baton found no positive net benefit in splitting the small fixture",
+        "scout_calls": [],
+        "git_clean": true,
+        "writes_before_approval": false,
+        "plan_verifier_role": "plan-verifier",
+        "plan_verifier_invocation_model": null,
+        "plan_verifier_observed_model": "claude-opus-4-8",
+        "plan_verifier_observed_tools": [
+          "Read",
+          "Grep"
+        ],
+        "verifier_sequence": [
+          "READY"
+        ],
+        "plan_revision_applied": false,
+        "plan_revision_summary": "none required; the readiness pass returned READY on the first Plan"
+      }
+    },
+    {
+      "id": "baton-compatibility-final-turn-2",
+      "source_pointer": "/final_gate/turns/1",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/final_gate",
+        "status": "passed",
+        "source_base_head": "4d65cc94b59acec2debec37983ad0a021440d643",
+        "release_candidate_version": "1.3.1",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-4-8",
+        "fast_mode": false,
+        "transcript_sha256": "6563b1c5f3d15f2640688a8509fa093364c5534f9246e0ee700e67c3469ac0b5",
+        "passed": true
+      },
+      "status": "passed_phase",
+      "boundary": "The passed gate records this execution and verification invocation as completed.",
+      "record": {
+        "cli_invocation": 2,
+        "prompt_turn": "turn-2",
+        "prompt_file_sha256": "82d833090ba91982651de9ac4beed8fc96311119c6eb9c6f0304c292821918e7",
+        "prompt_runtime_input_sha256": "93ae95d1cd4eebca91ab42a06d484e180f46dd1f327e471a5a4fd2a27ca2f344",
+        "max_budget_usd": 6,
+        "phase": "approved_execution_verification",
+        "disposition": "completed",
+        "wall_seconds": 278.34,
+        "duration_ms": 276613,
+        "duration_api_ms": 275037,
+        "num_turns": 5,
+        "client_reported_cost_usd": 1.7779397,
+        "models": [
+          "claude-opus-4-8",
+          "claude-sonnet-5"
+        ],
+        "writer": "mech-executor",
+        "writer_invocation_model": null,
+        "writer_observed_model": "claude-sonnet-5",
+        "writer_observed_tools": [
+          "Bash",
+          "Write"
+        ],
+        "writer_direct_write_blocked_by_hook": true,
+        "integration_write_owner": "main_session",
+        "integration_note": "The worker returned the complete report content after the existing hook rejected its Write; the main session integrated that content without changing scope.",
+        "verifier": "verifier",
+        "verifier_invocation_model": null,
+        "verifier_observed_model": "claude-opus-4-8",
+        "verifier_observed_tools": [
+          "Bash"
+        ],
+        "only_change": "?? REPORT.md",
+        "git_status": "?? REPORT.md",
+        "report_sha256": "71357915fed0d4572a1cff5cda78816bad46b4d1a10f4c3750eb63f6b8783cdf",
+        "report_lines": 64,
+        "report_bytes": 7274,
+        "citation_surfaces": [
+          "surface-a/",
+          "surface-b/"
+        ],
+        "test_command": "npm test",
+        "test_passed": true,
+        "test_output": "REPORT.md covers both independent surfaces with file:line evidence",
+        "verifier_sequence": [
+          "CONFIRMED"
+        ],
+        "verifier_note": "The verifier disclosed one non-blocking wording issue: architecture.md:72-78 includes two non-role rows, so calling the whole range a per-role tier table is broader than the source. It did not refute the audited claim."
+      }
+    },
+    {
+      "id": "baton-compatibility-v1-3-2-turn-1",
+      "source_pointer": "/v1_3_2_release_gate/turns/0",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/v1_3_2_release_gate",
+        "status": "passed",
+        "source_base_head": "fc0a2aa7caaf89d00fd2111642b13e28ce8e2bd5",
+        "release_candidate_version": "1.3.2",
+        "claude_code": "2.1.218",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-4-8",
+        "provider_route": "native Claude first-party authentication",
+        "fast_mode": false,
+        "orchestration_sha256": "b42bd2f0d6c4be23472020cc107d6ceb4ab0eb34553ccfcac5fe6e65c9164b4b",
+        "agents_json_runtime_sha256": "183c1b4ecfa7e40fcff5dca80abbcf339bbfd9530722dab9feac5e1ecceae1d1",
+        "transcript_sha256": "282146ad3eaaa94227c7ff2f6a1959ae210459af59dfab9939c3b96daec4cd44",
+        "passed": true
+      },
+      "status": "passed_phase",
+      "boundary": "The passed release gate records this discovery and approval invocation as completed.",
+      "record": {
+        "cli_invocation": 1,
+        "prompt_turn": "v1.3.2-turn-1",
+        "max_budget_usd": 6,
+        "phase": "discovery_sliced_plan_approval_wait",
+        "disposition": "completed",
+        "duration_ms": 273977,
+        "duration_api_ms": 273017,
+        "num_turns": 15,
+        "client_reported_cost_usd": 1.49627725,
+        "models": [
+          "claude-opus-4-8"
+        ],
+        "baton_loaded": true,
+        "discovery_topology": "direct main-session read",
+        "git_clean": true,
+        "writes_before_approval": false,
+        "readiness_units": [
+          {
+            "id": "ENV-report-audit",
+            "kind": "program envelope",
+            "role": "plan-verifier",
+            "background": false,
+            "invocation_model": null,
+            "observed_model": "claude-opus-4-8",
+            "observed_tools": [
+              "Read",
+              "Grep"
+            ],
+            "verdict": "READY"
+          },
+          {
+            "id": "S1-report",
+            "kind": "execution slice",
+            "role": "plan-verifier",
+            "background": false,
+            "invocation_model": null,
+            "observed_model": "claude-opus-4-8",
+            "observed_tools": [
+              "Read",
+              "Grep"
+            ],
+            "verdict": "READY"
+          }
+        ],
+        "deferred_unit": "S2-followup"
+      }
+    },
+    {
+      "id": "baton-compatibility-v1-3-2-turn-2",
+      "source_pointer": "/v1_3_2_release_gate/turns/1",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/v1_3_2_release_gate",
+        "status": "passed",
+        "source_base_head": "fc0a2aa7caaf89d00fd2111642b13e28ce8e2bd5",
+        "release_candidate_version": "1.3.2",
+        "claude_code": "2.1.218",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-4-8",
+        "provider_route": "native Claude first-party authentication",
+        "fast_mode": false,
+        "orchestration_sha256": "b42bd2f0d6c4be23472020cc107d6ceb4ab0eb34553ccfcac5fe6e65c9164b4b",
+        "agents_json_runtime_sha256": "183c1b4ecfa7e40fcff5dca80abbcf339bbfd9530722dab9feac5e1ecceae1d1",
+        "transcript_sha256": "282146ad3eaaa94227c7ff2f6a1959ae210459af59dfab9939c3b96daec4cd44",
+        "passed": true
+      },
+      "status": "passed_phase",
+      "boundary": "The passed release gate records final-byte tests and a CONFIRMED verifier for this execution invocation.",
+      "record": {
+        "cli_invocation": 2,
+        "prompt_turn": "v1.3.2-turn-2",
+        "max_budget_usd": 6,
+        "phase": "approved_slice_execution_verification",
+        "disposition": "completed",
+        "duration_ms": 171033,
+        "duration_api_ms": 170399,
+        "num_turns": 4,
+        "client_reported_cost_usd": 1.2808205,
+        "models": [
+          "claude-opus-4-8"
+        ],
+        "approved_units": [
+          "ENV-report-audit",
+          "S1-report"
+        ],
+        "writer": "main_session",
+        "only_change": "?? REPORT.md",
+        "git_status": "?? REPORT.md",
+        "report_sha256": "d77785dd310ddddae8f99e64b3622c2012101142636ae3ec5081f4a0dbb5ee3d",
+        "report_lines": 31,
+        "report_bytes": 3723,
+        "citation_count": 23,
+        "test_command": "npm test",
+        "test_passed": true,
+        "independent_final_byte_test_passed": true,
+        "verifier": {
+          "role": "verifier",
+          "background": false,
+          "invocation_model": null,
+          "observed_model": "claude-opus-4-8",
+          "observed_tools": [
+            "Bash",
+            "Read"
+          ],
+          "verdict": "CONFIRMED"
+        },
+        "deferred_unit_executed": false
+      }
+    },
+    {
+      "id": "baton-compatibility-opus5-turn-1",
+      "source_pointer": "/v1_3_2_opus5_release_gate/turns/0",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/v1_3_2_opus5_release_gate",
+        "status": "passed_with_corrective_verification",
+        "run_date": "2026-07-25",
+        "source_pr_url": "https://github.com/Nanako0129/pilotfish/pull/25",
+        "proposed_install_version": "1.3.3",
+        "claude_code": "2.1.219",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "provider_route": "native Claude first-party authentication",
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "fast_mode": false,
+        "orchestration_sha256": "b42bd2f0d6c4be23472020cc107d6ceb4ab0eb34553ccfcac5fe6e65c9164b4b",
+        "agents_json_runtime_sha256": "f272948d82cd4320f24ca849f884f5e1b74c04c23d28271753281bfdd9ffcaba",
+        "settings_sha256": "108da7014d44b2078581f9f98008b6f9d6c7ed08e5c9c7e93a7dd2f083f1a5d9",
+        "transcript_sha256": "c27c8de57e3c059879cac7caf6f184703af5f3a75bb7d0e9fa5653d6a6cbcd1f",
+        "passed": true
+      },
+      "status": "passed_phase",
+      "boundary": "The release gate records both readiness units reaching READY in this discovery invocation.",
+      "record": {
+        "cli_invocation": 1,
+        "prompt_turn": "v1.3.2-turn-1",
+        "max_budget_usd": 6,
+        "phase": "discovery_sliced_plan_approval_wait",
+        "disposition": "completed",
+        "duration_ms": 408315,
+        "duration_api_ms": 562239,
+        "num_turns": 7,
+        "client_reported_cost_usd": 2.66763805,
+        "models": [
+          "claude-haiku-4-5-20251001",
+          "claude-opus-5"
+        ],
+        "baton_loaded": true,
+        "discovery_topology": "two disjoint background scouts",
+        "git_clean": true,
+        "writes_before_approval": false,
+        "readiness_units": [
+          {
+            "id": "ENV-report-audit",
+            "kind": "program envelope",
+            "role": "plan-verifier",
+            "background": false,
+            "invocation_model": null,
+            "observed_model": "claude-opus-5",
+            "observed_tools": [
+              "Glob",
+              "Read"
+            ],
+            "verdicts": [
+              "REVISE",
+              "READY"
+            ]
+          },
+          {
+            "id": "S1-report",
+            "kind": "execution slice",
+            "role": "plan-verifier",
+            "background": false,
+            "invocation_model": null,
+            "observed_model": "claude-opus-5",
+            "observed_tools": [
+              "Glob",
+              "Read"
+            ],
+            "verdicts": [
+              "REVISE",
+              "READY"
+            ]
+          }
+        ],
+        "deferred_unit": "S2-followup"
+      }
+    },
+    {
+      "id": "baton-compatibility-opus5-turn-2b",
+      "source_pointer": "/v1_3_2_opus5_release_gate/turns/2",
+      "record_class": "corrective_verification",
+      "candidate_identity": {
+        "gate_pointer": "/v1_3_2_opus5_release_gate",
+        "status": "passed_with_corrective_verification",
+        "run_date": "2026-07-25",
+        "source_pr_url": "https://github.com/Nanako0129/pilotfish/pull/25",
+        "proposed_install_version": "1.3.3",
+        "claude_code": "2.1.219",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "provider_route": "native Claude first-party authentication",
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "fast_mode": false,
+        "orchestration_sha256": "b42bd2f0d6c4be23472020cc107d6ceb4ab0eb34553ccfcac5fe6e65c9164b4b",
+        "agents_json_runtime_sha256": "f272948d82cd4320f24ca849f884f5e1b74c04c23d28271753281bfdd9ffcaba",
+        "settings_sha256": "108da7014d44b2078581f9f98008b6f9d6c7ed08e5c9c7e93a7dd2f083f1a5d9",
+        "transcript_sha256": "c27c8de57e3c059879cac7caf6f184703af5f3a75bb7d0e9fa5653d6a6cbcd1f",
+        "passed": true
+      },
+      "status": "passed_phase",
+      "boundary": "This corrective invocation independently verified the final bytes after the preceding post-verdict edit.",
+      "record": {
+        "cli_invocation": 3,
+        "prompt_turn": "v1.3.2-opus5-turn-2b",
+        "max_budget_usd": 2,
+        "phase": "corrective_final_byte_verification",
+        "disposition": "completed",
+        "duration_ms": 10867,
+        "duration_api_ms": 115184,
+        "num_turns": 2,
+        "client_reported_cost_usd": 1.4398525,
+        "models": [
+          "claude-opus-5"
+        ],
+        "only_change": "?? REPORT.md",
+        "git_status": "?? REPORT.md",
+        "report_sha256": "bcbc74b759884816c6b065ba1026a4c7a765e4a925dfd5d4e3b8f30d270393e1",
+        "report_lines": 87,
+        "report_bytes": 7385,
+        "citation_occurrences": 38,
+        "distinct_citations": 30,
+        "test_command": "npm test",
+        "test_passed": true,
+        "independent_final_byte_test_passed": true,
+        "verifier": {
+          "role": "verifier",
+          "background": true,
+          "invocation_model": null,
+          "observed_model": "claude-opus-5",
+          "observed_tools": [
+            "Bash",
+            "Read"
+          ],
+          "verdict": "CONFIRMED"
+        },
+        "writes_during_corrective_verification": false,
+        "deferred_unit_executed": false
+      }
+    },
+    {
+      "id": "baton-compatibility-superseded-turn-1",
+      "source_pointer": "/superseded_candidate_gate/turns/0",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/superseded_candidate_gate",
+        "status": "superseded",
+        "source_commit": "40f38151581b890c7aec64218a95758045dfec57",
+        "release_candidate_version": "1.3.0",
+        "orchestration_sha256": "dc765dfc22b2c1875101ce665e8b3bba5968ff2549556459e5c2a8c847da0f44",
+        "agents_json_sha256": "e901e16abdca03ea5f55e3d86f8726fcfa984488305e304c7a382426cd6b7c61",
+        "transcript_sha256": "ff58d7ae7940367ad9921026ed8c7c32db11de032055402a875824b1450ad76f",
+        "passed": true,
+        "passed_at_the_time": true
+      },
+      "status": "passed_phase",
+      "boundary": "The superseded gate passed at the time and records this discovery invocation as completed.",
+      "record": {
+        "cli_invocation": 1,
+        "prompt_turn": "turn-1",
+        "phase": "discovery_plan_approval_wait",
+        "disposition": "completed",
+        "duration_ms": 159032,
+        "duration_api_ms": 156829,
+        "num_turns": 18,
+        "client_reported_cost_usd": 1.8466575,
+        "models": [
+          "claude-fable-5",
+          "claude-opus-4-8"
+        ],
+        "baton_loaded": true,
+        "discovery_topology": "direct main-session read",
+        "git_clean": true,
+        "plan_verifier_role": "plan-verifier",
+        "plan_verifier_observed_tools": [
+          "Read"
+        ],
+        "verifier_sequence": [
+          "READY"
+        ],
+        "plan_revision_applied": false,
+        "plan_revision_summary": "none required; the readiness pass returned READY on the first Plan"
+      }
+    },
+    {
+      "id": "baton-compatibility-superseded-turn-2-resume",
+      "source_pointer": "/superseded_candidate_gate/turns/2",
+      "record_class": "resumed_invocation",
+      "candidate_identity": {
+        "gate_pointer": "/superseded_candidate_gate",
+        "status": "superseded",
+        "source_commit": "40f38151581b890c7aec64218a95758045dfec57",
+        "release_candidate_version": "1.3.0",
+        "orchestration_sha256": "dc765dfc22b2c1875101ce665e8b3bba5968ff2549556459e5c2a8c847da0f44",
+        "agents_json_sha256": "e901e16abdca03ea5f55e3d86f8726fcfa984488305e304c7a382426cd6b7c61",
+        "transcript_sha256": "ff58d7ae7940367ad9921026ed8c7c32db11de032055402a875824b1450ad76f",
+        "passed": true,
+        "passed_at_the_time": true
+      },
+      "status": "passed_resumed_completion",
+      "boundary": "CLI invocation 3 resumed CLI invocation 2 in the same session and completed tests and verification.",
+      "record": {
+        "cli_invocation": 3,
+        "prompt_turn": "turn-2",
+        "phase": "approved_execution_verification",
+        "disposition": "resumed_completion",
+        "duration_ms": 85021,
+        "duration_api_ms": 79359,
+        "num_turns": 3,
+        "client_reported_cost_usd": 1.67602825,
+        "models": [
+          "claude-fable-5",
+          "claude-opus-4-8"
+        ],
+        "resume": {
+          "resumed_cli_invocation": 2,
+          "same_session": true,
+          "prompt": "verbatim turn-2 prompt"
+        },
+        "writer": "main_session",
+        "only_change": "REPORT.md",
+        "report_sha256": "55a3f5cde62f5e6e21b4bc95c27eabe1537098993d8291d3d60a0ecee340ea20",
+        "report_lines": 34,
+        "report_bytes": 6485,
+        "citation_count": 45,
+        "test_passed": true,
+        "verifier_sequence": [
+          "CONFIRMED"
+        ]
+      }
+    }
+  ],
+  "failed_attempts": [
+    {
+      "id": "baton-compatibility-opus5-turn-2",
+      "source_pointer": "/v1_3_2_opus5_release_gate/turns/1",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/v1_3_2_opus5_release_gate",
+        "status": "passed_with_corrective_verification",
+        "run_date": "2026-07-25",
+        "source_pr_url": "https://github.com/Nanako0129/pilotfish/pull/25",
+        "proposed_install_version": "1.3.3",
+        "claude_code": "2.1.219",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "provider_route": "native Claude first-party authentication",
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "fast_mode": false,
+        "orchestration_sha256": "b42bd2f0d6c4be23472020cc107d6ceb4ab0eb34553ccfcac5fe6e65c9164b4b",
+        "agents_json_runtime_sha256": "f272948d82cd4320f24ca849f884f5e1b74c04c23d28271753281bfdd9ffcaba",
+        "settings_sha256": "108da7014d44b2078581f9f98008b6f9d6c7ed08e5c9c7e93a7dd2f083f1a5d9",
+        "transcript_sha256": "c27c8de57e3c059879cac7caf6f184703af5f3a75bb7d0e9fa5653d6a6cbcd1f",
+        "passed": true
+      },
+      "status": "verification_invalidated_by_post_verdict_edit",
+      "boundary": "A post-verdict edit meant the initial verifier did not cover final bytes; accepted_as_final and initial_verdict_covers_final_bytes are false.",
+      "record": {
+        "cli_invocation": 2,
+        "prompt_turn": "v1.3.2-turn-2",
+        "max_budget_usd": 6,
+        "phase": "approved_slice_execution_initial_verification",
+        "disposition": "completed_with_post_verdict_edit",
+        "duration_ms": 34671,
+        "duration_api_ms": 292368,
+        "num_turns": 3,
+        "client_reported_cost_usd": 1.4412844,
+        "models": [
+          "claude-opus-5",
+          "claude-sonnet-5"
+        ],
+        "approved_units": [
+          "ENV-report-audit",
+          "S1-report"
+        ],
+        "writer": "main_session_after_mech_executor_write_guard",
+        "only_change": "?? REPORT.md",
+        "git_status": "?? REPORT.md",
+        "test_command": "npm test",
+        "test_passed": true,
+        "initial_verifier": {
+          "role": "verifier",
+          "background": true,
+          "invocation_model": null,
+          "observed_model": "claude-opus-5",
+          "observed_tools": [
+            "Bash",
+            "Read"
+          ],
+          "verdict": "CONFIRMED"
+        },
+        "post_verdict_edit": true,
+        "initial_verdict_covers_final_bytes": false,
+        "accepted_as_final": false,
+        "deferred_unit_executed": false
+      }
+    },
+    {
+      "id": "baton-compatibility-rejected-user-source-turn-1",
+      "source_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/turn_1",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/v1_3_2_opus5_rejected_user_source_attempt",
+        "status": "rejected",
+        "run_date": "2026-07-25",
+        "source_pr_url": "https://github.com/Nanako0129/pilotfish/pull/25",
+        "claude_code": "2.1.219",
+        "setting_sources": [
+          "user",
+          "project",
+          "local"
+        ],
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-4-8",
+        "passed": false
+      },
+      "status": "rejected_wrong_route",
+      "boundary": "The attempt included the user setting source so the installed Baton skill would load. Both this attempt and a separate explicit --model opus probe resolved to claude-opus-4-8, so neither exercised the proposed Opus 5 default. The evidence records the source-dependent difference without attributing its cause.",
+      "record": {
+        "duration_ms": 231717,
+        "duration_api_ms": 230556,
+        "num_turns": 15,
+        "client_reported_cost_usd": 1.5908975,
+        "git_clean": true,
+        "writes_before_approval": false,
+        "both_readiness_units_ready": true,
+        "turn_2_started": false,
+        "raw_result_sha256": "177af0ccf60210631676f2c3fde9215980a91cdbb67d90d743c744316d6a0b4d",
+        "transcript_sha256": "f864be1dc4c9abbc6c54758005c7e2b5b9ddd6cf9fd21c83a7cf087ac5a412ff"
+      }
+    },
+    {
+      "id": "baton-compatibility-rejected-user-source-route-probe",
+      "source_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe",
+      "record_class": "route_probe",
+      "candidate_identity": {
+        "gate_pointer": "/v1_3_2_opus5_rejected_user_source_attempt",
+        "status": "rejected",
+        "run_date": "2026-07-25",
+        "source_pr_url": "https://github.com/Nanako0129/pilotfish/pull/25",
+        "claude_code": "2.1.219",
+        "setting_sources": [
+          "user",
+          "project",
+          "local"
+        ],
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-4-8",
+        "passed": false
+      },
+      "status": "rejected_wrong_route",
+      "boundary": "The independent route probe resolved to claude-opus-4-8 instead of the proposed Opus 5 route, and its raw result was not persisted.",
+      "record": {
+        "no_session_persistence": true,
+        "duration_ms": 1606,
+        "duration_api_ms": 1463,
+        "num_turns": 1,
+        "client_reported_cost_usd": 0.169445,
+        "result": "EXPLICIT_OPUS_ROUTE_OK",
+        "observed_model": "claude-opus-4-8",
+        "raw_result_persisted": false
+      }
+    },
+    {
+      "id": "baton-compatibility-failed-candidate-turn-1",
+      "source_pointer": "/failed_candidate_gate/turns/0",
+      "record_class": "lifecycle_turn",
+      "candidate_identity": {
+        "gate_pointer": "/failed_candidate_gate",
+        "status": "failed",
+        "source_base_head": "a38dd2dde000441b24881fa49495e545ff21b9e6",
+        "release_candidate_version": "1.3.0",
+        "fast_mode": false,
+        "policy_orchestration_sha256": "d41a9d41db21e97176e82614dcfd4d80cba670ec28136666cc96906dd5efda35",
+        "orchestration_sha256": "d41a9d41db21e97176e82614dcfd4d80cba670ec28136666cc96906dd5efda35",
+        "agents_json_sha256": "e901e16abdca03ea5f55e3d86f8726fcfa984488305e304c7a382426cd6b7c61",
+        "transcript_sha256": "250b8cd8b53e758299b233d16c2753890a46c6284a99a8d21ba5d5e907bf7ebc",
+        "passed": false
+      },
+      "status": "budget_exhausted",
+      "boundary": "The run stopped at the budget limit after a READY Plan; the old turn-1 prompt did not require the approved turn to invoke the closing outcome verifier.",
+      "record": {
+        "cli_invocation": 1,
+        "prompt_turn": "turn-1",
+        "prompt_file_sha256": "edce6a591e5879769b89b0fff0f4aa8c64e038f79b93e6a804161e4f9914624f",
+        "prompt_runtime_input_sha256": "8aa4459acbb2f96df4617dcbf2b147c91222252a48c8fac754f344bc2d32d2fb",
+        "phase": "discovery_plan_approval_wait",
+        "disposition": "budget_exhausted",
+        "duration_ms": 218040,
+        "duration_api_ms": 186738,
+        "num_turns": 13,
+        "client_reported_cost_usd": 4.12912975,
+        "models": [
+          "claude-fable-5",
+          "claude-opus-4-8"
+        ],
+        "max_budget_usd": 3,
+        "terminal_status": "budget_exhausted",
+        "baton_loaded": true,
+        "git_clean": true,
+        "writes_before_approval": false,
+        "plan_verifier_role": "plan-verifier",
+        "plan_verifier_invocation_model": null,
+        "plan_verifier_observed_model": "claude-opus-4-8",
+        "plan_verifier_observed_tools": [
+          "Read"
+        ],
+        "verifier_sequence": [
+          "READY"
+        ],
+        "closing_outcome_verifier_required": true,
+        "closing_outcome_verifier_invoked": false,
+        "failure_reasons": [
+          "budget exhausted before the full lifecycle completed",
+          "acceptance-contract prompt ambiguity omitted the mandatory closing outcome verifier"
+        ],
+        "failure_summary": "The run stopped at the budget limit after a READY Plan; the old turn-1 prompt did not require the approved turn to invoke the closing outcome verifier."
+      }
+    },
+    {
+      "id": "baton-compatibility-superseded-turn-2-interrupted",
+      "source_pointer": "/superseded_candidate_gate/turns/1",
+      "record_class": "interrupted_invocation",
+      "candidate_identity": {
+        "gate_pointer": "/superseded_candidate_gate",
+        "status": "superseded",
+        "source_commit": "40f38151581b890c7aec64218a95758045dfec57",
+        "release_candidate_version": "1.3.0",
+        "orchestration_sha256": "dc765dfc22b2c1875101ce665e8b3bba5968ff2549556459e5c2a8c847da0f44",
+        "agents_json_sha256": "e901e16abdca03ea5f55e3d86f8726fcfa984488305e304c7a382426cd6b7c61",
+        "transcript_sha256": "ff58d7ae7940367ad9921026ed8c7c32db11de032055402a875824b1450ad76f",
+        "passed": true,
+        "passed_at_the_time": true
+      },
+      "status": "interrupted",
+      "boundary": "after REPORT.md was written, before npm test and outcome verification",
+      "record": {
+        "cli_invocation": 2,
+        "prompt_turn": "turn-2",
+        "phase": "approved_execution",
+        "disposition": "interrupted",
+        "duration_ms": 46941,
+        "duration_api_ms": 46241,
+        "num_turns": 2,
+        "client_reported_cost_usd": 1.081003,
+        "models": [
+          "claude-fable-5"
+        ],
+        "is_error": true,
+        "interruption": {
+          "cause": "subscription model limit reached mid-run; client message: \"You've reached your Fable 5 limit.\"",
+          "boundary": "after REPORT.md was written, before npm test and outcome verification",
+          "resume": "operator enabled usage credits; resumed with the same session id and the verbatim turn-2 prompt"
+        }
+      }
+    }
+  ],
+  "unknown_attempt_counts": [
+    {
+      "id": "baton-compatibility-previous-release-summary",
+      "source_pointer": "/previous_release_gate",
+      "status": "attempt_count_unknown",
+      "recorded_outcome": "unknown",
+      "reason": "The source marks this record granularity summary and retains neither turns nor total_cli_invocations. num_turns is not an invocation count.",
+      "record": {
+        "granularity": "summary",
+        "release_candidate_version": "1.2.1",
+        "source_commit": "80b5d1fe5c829f471ed65bba78357df85bdb4f16",
+        "transcript_sha256": "1beba30b94ec6ee6f74fa96cb880c8a8ecabbdf335a7c3542fda0c99521575a3",
+        "final_gate_orchestration_sha256": "fa1e3f19dfa3649fc341254da5a8fdaa116bfdb61181101672c7afddcb7a7188",
+        "final_gate_agents_json_sha256": "e901e16abdca03ea5f55e3d86f8726fcfa984488305e304c7a382426cd6b7c61",
+        "release_candidate_orchestration_sha256": "fa1e3f19dfa3649fc341254da5a8fdaa116bfdb61181101672c7afddcb7a7188",
+        "total_duration_ms": 368395,
+        "total_num_turns": 17,
+        "total_client_reported_cost_usd": 3.7104345,
+        "note": "The exact v1.2.1 final snapshot remains available in Git history at the source commit; this retained record is summary-only."
+      }
+    },
+    {
+      "id": "baton-compatibility-historical-release-summary",
+      "source_pointer": "/historical_release_gate",
+      "status": "attempt_count_unknown",
+      "recorded_outcome": "unknown",
+      "reason": "The source marks this record granularity summary and retains neither turns nor total_cli_invocations. num_turns is not an invocation count.",
+      "record": {
+        "granularity": "summary",
+        "release_candidate_version": "1.2.0",
+        "source_commit": "125146508587d69eab1265b00210a59d1e5b375f",
+        "transcript_sha256": "022871ac102442caeb6f902449442d8ccea5248617efafb4bb59dbce237c2569",
+        "final_gate_orchestration_sha256": "46977d982ebdb244428ae3c45240dcdaedc2f8cb5668032e0bf11c6093a2f9ff",
+        "final_gate_agents_json_sha256": "b3b45557491e9a92aecacab8a05d4c78c3b8f5dc9b26a5c5683f48c5f22bf3f7",
+        "release_candidate_orchestration_sha256": "5760abdeaf55a58c3db6b3f0e3de2c4aa69d303bfd83989b2707a9b00454d9d3",
+        "total_duration_ms": 448148,
+        "total_num_turns": 22,
+        "total_client_reported_cost_usd": 3.7890481,
+        "note": "Restored from the origin/main v1.2.1 evidence record; the exact v1.2.0 final snapshot remains available in Git history at the source commit. This retained record is summary-only."
+      }
+    },
+    {
+      "id": "baton-compatibility-superseded-summary",
+      "source_pointer": "/superseded_gate",
+      "status": "attempt_count_unknown",
+      "recorded_outcome": "passed_at_the_time",
+      "reason": "The source marks this record granularity summary and retains neither turns nor total_cli_invocations. num_turns is not an invocation count.",
+      "record": {
+        "granularity": "summary",
+        "transcript_sha256": "ed10fabf6b4daf38d1cf7c87ff8cd2eb0fb1042873140fcc0d097d872e7bf874",
+        "total_duration_ms": 494933,
+        "total_num_turns": 12,
+        "total_client_reported_cost_usd": 3.906375,
+        "plan_role": "verifier",
+        "outcome_role": "verifier",
+        "passed_at_the_time": true,
+        "superseded_reason": "Codex review found that the dual-mode verifier and pre-approval security analysis relied on prompt-only no-write boundaries; the final candidate split them into tool-enforced read-only roles and reran the lifecycle. Invocation detail was not retained, so this record remains summary-only."
+      }
+    },
+    {
+      "id": "baton-compatibility-rejected-harness-summary",
+      "source_pointer": "/rejected_harness_run",
+      "status": "attempt_count_unknown",
+      "recorded_outcome": "rejected",
+      "reason": "The source marks this record granularity summary and retains neither turns nor total_cli_invocations. num_turns is not an invocation count.",
+      "record": {
+        "granularity": "summary",
+        "transcript_sha256": "64376ea52a4e67192df29d8595c180ddc5017638029759a8ac13aff87d5cca81",
+        "duration_ms": 213558,
+        "num_turns": 17,
+        "client_reported_cost_usd": 1.6278745,
+        "git_clean": true,
+        "plan_verdict": "READY",
+        "second_turn_started": false,
+        "rejection_reason": "--setting-sources project,local hid the user-installed baton-dispatch skill, so the run did not test the requested composition"
+      }
+    }
+  ],
+  "not_run": [
+    {
+      "source_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/turn_1/turn_2_started",
+      "status": "not_run",
+      "reason": "The rejected source-composition attempt stopped after turn 1; the recorded boolean is false."
+    }
+  ]
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -5081,6 +5081,441 @@ class PolicyContractTests(unittest.TestCase):
             )
         self.assertNotIn("interrupted_invocation", json.dumps(results, default=str))
 
+    def test_baton_compatibility_attempts_are_source_bound(self) -> None:
+        benchmark = ROOT / "benchmarks" / "baton-compatibility"
+        ledger = json.loads(
+            (benchmark / "attempts.json").read_text(encoding="utf-8"),
+            parse_float=Decimal,
+        )
+        source_bytes = (benchmark / "results.json").read_bytes()
+        source = json.loads(source_bytes, parse_float=Decimal)
+        expected_source_keys = {
+            "schema_version",
+            "run_date",
+            "timezone",
+            "fixture",
+            "runtime",
+            "final_gate_status",
+            "previous_final_gate",
+            "final_gate",
+            "v1_3_2_release_gate",
+            "v1_3_2_opus5_release_gate",
+            "v1_3_2_opus5_rejected_user_source_attempt",
+            "v1_3_2_post_gate_role_change",
+            "failed_candidate_gate",
+            "previous_release_gate",
+            "historical_release_gate",
+            "superseded_candidate_gate",
+            "superseded_gate",
+            "rejected_harness_run",
+            "unexercised_controls",
+            "post_gate_role_frontmatter_change",
+        }
+        invocation_pointers = [
+            "/previous_final_gate/turns/0",
+            "/previous_final_gate/turns/1",
+            "/final_gate/turns/0",
+            "/final_gate/turns/1",
+            "/v1_3_2_release_gate/turns/0",
+            "/v1_3_2_release_gate/turns/1",
+            "/v1_3_2_opus5_release_gate/turns/0",
+            "/v1_3_2_opus5_release_gate/turns/1",
+            "/v1_3_2_opus5_release_gate/turns/2",
+            "/v1_3_2_opus5_rejected_user_source_attempt/turn_1",
+            "/v1_3_2_opus5_rejected_user_source_attempt/explicit_route_probe",
+            "/failed_candidate_gate/turns/0",
+            "/superseded_candidate_gate/turns/0",
+            "/superseded_candidate_gate/turns/1",
+            "/superseded_candidate_gate/turns/2",
+        ]
+        unknown_pointers = [
+            "/previous_release_gate",
+            "/historical_release_gate",
+            "/superseded_gate",
+            "/rejected_harness_run",
+        ]
+        excluded_pointers = [
+            "/v1_3_2_post_gate_role_change",
+            "/unexercised_controls",
+            "/post_gate_role_frontmatter_change",
+        ]
+        passed_specs = [
+            (
+                "baton-compatibility-previous-final-turn-1",
+                invocation_pointers[0],
+                "lifecycle_turn",
+                "passed_phase",
+                "The passed gate records this discovery and approval invocation as completed.",
+            ),
+            (
+                "baton-compatibility-previous-final-turn-2",
+                invocation_pointers[1],
+                "lifecycle_turn",
+                "passed_phase",
+                "The passed gate records this execution and verification invocation as completed.",
+            ),
+            (
+                "baton-compatibility-final-turn-1",
+                invocation_pointers[2],
+                "lifecycle_turn",
+                "passed_phase",
+                "The passed gate records this discovery and approval invocation as completed.",
+            ),
+            (
+                "baton-compatibility-final-turn-2",
+                invocation_pointers[3],
+                "lifecycle_turn",
+                "passed_phase",
+                "The passed gate records this execution and verification invocation as completed.",
+            ),
+            (
+                "baton-compatibility-v1-3-2-turn-1",
+                invocation_pointers[4],
+                "lifecycle_turn",
+                "passed_phase",
+                "The passed release gate records this discovery and approval invocation as completed.",
+            ),
+            (
+                "baton-compatibility-v1-3-2-turn-2",
+                invocation_pointers[5],
+                "lifecycle_turn",
+                "passed_phase",
+                "The passed release gate records final-byte tests and a CONFIRMED verifier for this execution invocation.",
+            ),
+            (
+                "baton-compatibility-opus5-turn-1",
+                invocation_pointers[6],
+                "lifecycle_turn",
+                "passed_phase",
+                "The release gate records both readiness units reaching READY in this discovery invocation.",
+            ),
+            (
+                "baton-compatibility-opus5-turn-2b",
+                invocation_pointers[8],
+                "corrective_verification",
+                "passed_phase",
+                "This corrective invocation independently verified the final bytes after the preceding post-verdict edit.",
+            ),
+            (
+                "baton-compatibility-superseded-turn-1",
+                invocation_pointers[12],
+                "lifecycle_turn",
+                "passed_phase",
+                "The superseded gate passed at the time and records this discovery invocation as completed.",
+            ),
+            (
+                "baton-compatibility-superseded-turn-2-resume",
+                invocation_pointers[14],
+                "resumed_invocation",
+                "passed_resumed_completion",
+                "CLI invocation 3 resumed CLI invocation 2 in the same session and completed tests and verification.",
+            ),
+        ]
+        failed_specs = [
+            (
+                "baton-compatibility-opus5-turn-2",
+                invocation_pointers[7],
+                "lifecycle_turn",
+                "verification_invalidated_by_post_verdict_edit",
+                "A post-verdict edit meant the initial verifier did not cover final bytes; accepted_as_final and initial_verdict_covers_final_bytes are false.",
+            ),
+            (
+                "baton-compatibility-rejected-user-source-turn-1",
+                invocation_pointers[9],
+                "lifecycle_turn",
+                "rejected_wrong_route",
+                source["v1_3_2_opus5_rejected_user_source_attempt"]["reason"],
+            ),
+            (
+                "baton-compatibility-rejected-user-source-route-probe",
+                invocation_pointers[10],
+                "route_probe",
+                "rejected_wrong_route",
+                "The independent route probe resolved to claude-opus-4-8 instead of the proposed Opus 5 route, and its raw result was not persisted.",
+            ),
+            (
+                "baton-compatibility-failed-candidate-turn-1",
+                invocation_pointers[11],
+                "lifecycle_turn",
+                "budget_exhausted",
+                source["failed_candidate_gate"]["turns"][0]["failure_summary"],
+            ),
+            (
+                "baton-compatibility-superseded-turn-2-interrupted",
+                invocation_pointers[13],
+                "interrupted_invocation",
+                "interrupted",
+                source["superseded_candidate_gate"]["turns"][1]["interruption"][
+                    "boundary"
+                ],
+            ),
+        ]
+        identity_keys = {
+            "status",
+            "passed",
+            "passed_at_the_time",
+            "source_base_head",
+            "source_commit",
+            "release_candidate_version",
+            "proposed_install_version",
+            "run_date",
+            "claude_code",
+            "requested_main_model",
+            "observed_main_model",
+            "setting_sources",
+            "provider_route",
+            "fast_mode",
+            "orchestration_sha256",
+            "policy_orchestration_sha256",
+            "agents_json_sha256",
+            "agents_json_runtime_sha256",
+            "settings_sha256",
+            "transcript_sha256",
+            "source_pr_url",
+        }
+
+        def resolve(pointer: str) -> object:
+            value: object = source
+            for token in pointer.removeprefix("/").split("/"):
+                if isinstance(value, dict):
+                    self.assertIn(token, value)
+                    value = value[token]
+                elif isinstance(value, list):
+                    self.assertTrue(token.isdigit())
+                    value = value[int(token)]
+                else:
+                    self.fail(f"cannot resolve {pointer!r}")
+            return value
+
+        def candidate_identity(pointer: str) -> dict:
+            gate_pointer = "/" + pointer.removeprefix("/").split("/", 1)[0]
+            parent = resolve(gate_pointer)
+            self.assertIsInstance(parent, dict)
+            return {
+                "gate_pointer": gate_pointer,
+                **{key: value for key, value in parent.items() if key in identity_keys},
+            }
+
+        def expected_detail(spec: tuple[str, str, str, str, str]) -> dict:
+            entry_id, pointer, record_class, status, boundary = spec
+            record = resolve(pointer)
+            self.assertIsInstance(record, dict)
+            return {
+                "id": entry_id,
+                "source_pointer": pointer,
+                "record_class": record_class,
+                "candidate_identity": candidate_identity(pointer),
+                "status": status,
+                "boundary": boundary,
+                "record": record,
+            }
+
+        unknown_specs = [
+            ("baton-compatibility-previous-release-summary", unknown_pointers[0], "unknown"),
+            ("baton-compatibility-historical-release-summary", unknown_pointers[1], "unknown"),
+            (
+                "baton-compatibility-superseded-summary",
+                unknown_pointers[2],
+                "passed_at_the_time",
+            ),
+            (
+                "baton-compatibility-rejected-harness-summary",
+                unknown_pointers[3],
+                "rejected",
+            ),
+        ]
+        unknown_reason = (
+            "The source marks this record granularity summary and retains neither "
+            "turns nor total_cli_invocations. num_turns is not an invocation count."
+        )
+
+        def expected_unknown(spec: tuple[str, str, str]) -> dict:
+            entry_id, pointer, outcome = spec
+            record = resolve(pointer)
+            self.assertIsInstance(record, dict)
+            return {
+                "id": entry_id,
+                "source_pointer": pointer,
+                "status": "attempt_count_unknown",
+                "recorded_outcome": outcome,
+                "reason": unknown_reason,
+                "record": record,
+            }
+
+        def validate(candidate: dict) -> None:
+            self.assertEqual(set(source), expected_source_keys)
+            for gate in (
+                "previous_final_gate",
+                "final_gate",
+                "v1_3_2_release_gate",
+                "v1_3_2_opus5_release_gate",
+                "failed_candidate_gate",
+                "superseded_candidate_gate",
+            ):
+                self.assertEqual(
+                    len(source[gate]["turns"]), source[gate]["total_cli_invocations"]
+                )
+                self.assertEqual(
+                    [turn["cli_invocation"] for turn in source[gate]["turns"]],
+                    list(range(1, len(source[gate]["turns"]) + 1)),
+                )
+            self.assertEqual(
+                set(candidate),
+                {
+                    "schema_version",
+                    "source",
+                    "counts",
+                    "coverage",
+                    "passed_attempts",
+                    "failed_attempts",
+                    "unknown_attempt_counts",
+                    "not_run",
+                },
+            )
+            self.assertEqual(candidate["schema_version"], 1)
+            self.assertEqual(
+                candidate["source"],
+                {
+                    "path": "results.json",
+                    "sha256": hashlib.sha256(source_bytes).hexdigest(),
+                },
+            )
+            self.assertEqual(
+                candidate["counts"],
+                {
+                    "attempted": 15,
+                    "passed": 10,
+                    "failed": 5,
+                    "unknown_invocation_count_records": 4,
+                },
+            )
+            self.assertEqual(
+                candidate["coverage"],
+                {
+                    "invocation_pointers": invocation_pointers,
+                    "unknown_invocation_count_pointers": unknown_pointers,
+                    "excluded_summary_pointers": excluded_pointers,
+                },
+            )
+            self.assertEqual(
+                candidate["passed_attempts"],
+                [expected_detail(spec) for spec in passed_specs],
+            )
+            self.assertEqual(
+                candidate["failed_attempts"],
+                [expected_detail(spec) for spec in failed_specs],
+            )
+            self.assertEqual(
+                candidate["unknown_attempt_counts"],
+                [expected_unknown(spec) for spec in unknown_specs],
+            )
+            self.assertEqual(
+                candidate["not_run"],
+                [
+                    {
+                        "source_pointer": "/v1_3_2_opus5_rejected_user_source_attempt/turn_1/turn_2_started",
+                        "status": "not_run",
+                        "reason": "The rejected source-composition attempt stopped after turn 1; the recorded boolean is false.",
+                    }
+                ],
+            )
+            self.assertFalse(resolve(candidate["not_run"][0]["source_pointer"]))
+            details = candidate["passed_attempts"] + candidate["failed_attempts"]
+            self.assertEqual(len(details), candidate["counts"]["attempted"])
+            self.assertEqual(len({entry["id"] for entry in details}), 15)
+            self.assertEqual(len({entry["source_pointer"] for entry in details}), 15)
+            self.assertEqual(
+                {entry["source_pointer"] for entry in details}, set(invocation_pointers)
+            )
+            self.assertTrue(
+                all(
+                    "/agent_calls/" not in pointer and "/scout_calls/" not in pointer
+                    for pointer in invocation_pointers
+                )
+            )
+            self.assertTrue(source["previous_final_gate"]["turns"][0]["scout_calls"])
+            opus_initial = candidate["failed_attempts"][0]["record"]
+            self.assertTrue(opus_initial["post_verdict_edit"])
+            self.assertFalse(opus_initial["initial_verdict_covers_final_bytes"])
+            self.assertFalse(opus_initial["accepted_as_final"])
+            route_probe = candidate["failed_attempts"][2]["record"]
+            self.assertFalse(route_probe["raw_result_persisted"])
+            self.assertNotIn("raw_result_sha256", route_probe)
+            interrupted = candidate["failed_attempts"][4]["record"]
+            resumed = candidate["passed_attempts"][-1]["record"]
+            self.assertTrue(interrupted["is_error"])
+            self.assertEqual(resumed["resume"]["resumed_cli_invocation"], 2)
+            self.assertTrue(resumed["resume"]["same_session"])
+            for summary in candidate["unknown_attempt_counts"]:
+                self.assertEqual(summary["record"]["granularity"], "summary")
+                self.assertNotIn("turns", summary["record"])
+                self.assertNotIn("total_cli_invocations", summary["record"])
+
+        validate(ledger)
+
+        missing = deepcopy(ledger)
+        missing["passed_attempts"].pop()
+        with self.assertRaises(AssertionError):
+            validate(missing)
+
+        aggregate = deepcopy(ledger)
+        aggregate["coverage"]["invocation_pointers"][0] = "/final_gate"
+        with self.assertRaises(AssertionError):
+            validate(aggregate)
+
+        for index in range(5):
+            flipped = deepcopy(ledger)
+            flipped["failed_attempts"][index]["status"] = "passed_phase"
+            with self.assertRaises(AssertionError):
+                validate(flipped)
+
+        replaced_source = deepcopy(ledger)
+        replaced_source["source"]["sha256"] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(replaced_source)
+
+        for target, key, value in (
+            ("candidate_identity", "gate_pointer", "/different"),
+            ("record", "client_reported_cost_usd", Decimal("0")),
+            (None, "boundary", "different"),
+        ):
+            replaced = deepcopy(ledger)
+            container = replaced["failed_attempts"][3]
+            if target is not None:
+                container = container[target]
+            container[key] = value
+            with self.assertRaises(AssertionError):
+                validate(replaced)
+
+        invented_raw = deepcopy(ledger)
+        invented_raw["failed_attempts"][2]["record"]["raw_result_sha256"] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(invented_raw)
+
+        inferred = deepcopy(ledger)
+        inferred["counts"]["attempted"] += inferred["unknown_attempt_counts"][0][
+            "record"
+        ]["total_num_turns"]
+        with self.assertRaises(AssertionError):
+            validate(inferred)
+
+        moved_summary = deepcopy(ledger)
+        moved_summary["passed_attempts"].append(moved_summary["unknown_attempt_counts"].pop())
+        with self.assertRaises(AssertionError):
+            validate(moved_summary)
+
+        collapsed_resume = deepcopy(ledger)
+        collapsed_resume["failed_attempts"].pop()
+        collapsed_resume["passed_attempts"].pop()
+        collapsed_resume["counts"] = {
+            "attempted": 13,
+            "passed": 9,
+            "failed": 4,
+            "unknown_invocation_count_records": 4,
+        }
+        with self.assertRaises(AssertionError):
+            validate(collapsed_resume)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

- account for all 15 detailed Baton compatibility CLI/probe records as 10 passes and 5 retained failures
- separate 4 summary-only historical records whose invocation counts are unknown instead of inferring from `num_turns`
- preserve the rejected second turn as not-run and the interrupted/resumed records as distinct CLI invocations
- exclude aggregate gates and child agent/scout calls with source-specific tamper checks

This is intentionally source-native. It does not recreate the universal discovery oracle closed as no-go in #70.

## Verification

- focused compatibility attempt contract
- full repository suite: 77/77
- renderer `--check` and Python syntax
- strict JSON duplicate-key parse
- source SHA-256 unchanged: `fd4c9271035f3f43aad8f7b51b69a831e7a62709c2d255a9c987b040308ac170`
- exact two-path scope and `git diff --check`
- fresh outcome verifier: `CONFIRMED` with independent alias tamper

No live or paid gate was run. Part of #65.