### PR TITLE
feat(benchmarks): bind compact policy attempts

### DIFF
--- a/benchmarks/spontaneous-dispatch/compact-policy-full-matrix.attempts.json
+++ b/benchmarks/spontaneous-dispatch/compact-policy-full-matrix.attempts.json
@@ -1,0 +1,509 @@
+{
+  "schema_version": 1,
+  "source": {
+    "path": "compact-policy-full-matrix.json",
+    "sha256": "ac3f4dabaabb17f3519d27f7841b1c144de347854df2efdd6746016668ca41a2"
+  },
+  "counts": {
+    "attempted": 10,
+    "passed": 10,
+    "failed": 0
+  },
+  "coverage": {
+    "source_pointer": "/results",
+    "invocation_pointers": [
+      "/results/routine_docs/attempts/0",
+      "/results/routine_docs/attempts/1",
+      "/results/single_unknown_bug/attempts/0",
+      "/results/single_unknown_bug/attempts/1",
+      "/results/mechanical_repetition/attempts/0",
+      "/results/mechanical_repetition/attempts/1",
+      "/results/schema_lifecycle/attempts/0/turn_1",
+      "/results/schema_lifecycle/attempts/0/turn_2",
+      "/results/schema_lifecycle/attempts/1/turn_1",
+      "/results/schema_lifecycle/attempts/1/turn_2"
+    ]
+  },
+  "passed_attempts": [
+    {
+      "id": "compact-policy-routine-a",
+      "source_pointer": "/results/routine_docs/attempts/0",
+      "cell": "routine_docs",
+      "attempt_id": "a",
+      "turn": null,
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "120ecc6c51894e6977dc2ac955827d5476d3ea83b2a7c610646598f1687f8ac7",
+        "fixture_sha256": "a94d2327102ca46ac35fe0af1a57ef17855910e205cb619d43f62b852ee9b46f",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata"
+      },
+      "status": "passed",
+      "record": {
+        "id": "a",
+        "agent_calls": 0,
+        "modified_paths": [
+          "README.md"
+        ],
+        "tests": "1 passed, 0 failed",
+        "client_reported_cost_usd": 0.241243,
+        "raw_stream_sha256": "1f52e4cf4690045373657c8abfbeaa6d1b0d5e6aaf960c712d798af49e314b9b"
+      }
+    },
+    {
+      "id": "compact-policy-routine-b",
+      "source_pointer": "/results/routine_docs/attempts/1",
+      "cell": "routine_docs",
+      "attempt_id": "b",
+      "turn": null,
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "120ecc6c51894e6977dc2ac955827d5476d3ea83b2a7c610646598f1687f8ac7",
+        "fixture_sha256": "a94d2327102ca46ac35fe0af1a57ef17855910e205cb619d43f62b852ee9b46f",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata"
+      },
+      "status": "passed",
+      "record": {
+        "id": "b",
+        "agent_calls": 0,
+        "modified_paths": [
+          "README.md"
+        ],
+        "tests": "1 passed, 0 failed",
+        "client_reported_cost_usd": 0.2081875,
+        "raw_stream_sha256": "57fdf99c7d16f36e6408a1ced5db6057677b2ffb1a69d2885bada24c8c798637"
+      }
+    },
+    {
+      "id": "compact-policy-bug-a",
+      "source_pointer": "/results/single_unknown_bug/attempts/0",
+      "cell": "single_unknown_bug",
+      "attempt_id": "a",
+      "turn": null,
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "ea238854c4d7dbb4421f368e9893db0c967a760b01fd15af057ed74e36156f90",
+        "fixture_sha256": "d5e0e35b96f25317750e28a495e249c745049eb9ffc7d0fcb6d51287c03f49eb",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata"
+      },
+      "status": "passed",
+      "record": {
+        "id": "a",
+        "agent_calls": 0,
+        "modified_paths": [
+          "src/reducer.js"
+        ],
+        "tests": "2 passed, 0 failed",
+        "client_reported_cost_usd": 0.339125,
+        "raw_stream_sha256": "33d0a7e646653f9e481270cd25c78dd75026b981833751356148f46f84a08ee5"
+      }
+    },
+    {
+      "id": "compact-policy-bug-b",
+      "source_pointer": "/results/single_unknown_bug/attempts/1",
+      "cell": "single_unknown_bug",
+      "attempt_id": "b",
+      "turn": null,
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "ea238854c4d7dbb4421f368e9893db0c967a760b01fd15af057ed74e36156f90",
+        "fixture_sha256": "d5e0e35b96f25317750e28a495e249c745049eb9ffc7d0fcb6d51287c03f49eb",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata"
+      },
+      "status": "passed",
+      "record": {
+        "id": "b",
+        "agent_calls": 0,
+        "modified_paths": [
+          "src/reducer.js"
+        ],
+        "tests": "2 passed, 0 failed",
+        "client_reported_cost_usd": 0.3485885,
+        "raw_stream_sha256": "cd51a69d3badadabbc91be7377886d2e553319beaf6170282c4dc0e10f6d0352"
+      }
+    },
+    {
+      "id": "compact-policy-mechanical-a",
+      "source_pointer": "/results/mechanical_repetition/attempts/0",
+      "cell": "mechanical_repetition",
+      "attempt_id": "a",
+      "turn": null,
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "a0a13600fbea1f927b97baacf095f48a265e38cf305adc75cc85f88d559a6dc6",
+        "fixture_sha256": "4dffc6efd10a630fd1e5842c133252f857314bb564d98bb7dac92bb1c315ea7b",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata"
+      },
+      "status": "passed",
+      "record": {
+        "id": "a",
+        "agent_calls": 1,
+        "agent_role": "mech-executor",
+        "invocation_model_present": false,
+        "foreground": true,
+        "collected": true,
+        "main_session_source_mutation": false,
+        "modified_paths": [
+          "src/adapters/alpha.js",
+          "src/adapters/bravo.js",
+          "src/adapters/charlie.js",
+          "src/adapters/delta.js",
+          "src/adapters/echo.js",
+          "src/adapters/foxtrot.js",
+          "src/adapters/golf.js",
+          "src/adapters/hotel.js",
+          "src/adapters/india.js",
+          "src/adapters/juliet.js",
+          "src/adapters/kilo.js",
+          "src/adapters/lima.js"
+        ],
+        "tests": "12 passed, 0 failed",
+        "client_reported_cost_usd": 0.5445181,
+        "raw_stream_sha256": "96620ba3717dfffbaed92841cdc495d06a40f80f2ed093223f8d5ebf9503d06a"
+      }
+    },
+    {
+      "id": "compact-policy-mechanical-b",
+      "source_pointer": "/results/mechanical_repetition/attempts/1",
+      "cell": "mechanical_repetition",
+      "attempt_id": "b",
+      "turn": null,
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "a0a13600fbea1f927b97baacf095f48a265e38cf305adc75cc85f88d559a6dc6",
+        "fixture_sha256": "4dffc6efd10a630fd1e5842c133252f857314bb564d98bb7dac92bb1c315ea7b",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata"
+      },
+      "status": "passed",
+      "record": {
+        "id": "b",
+        "agent_calls": 1,
+        "agent_role": "mech-executor",
+        "invocation_model_present": false,
+        "foreground": true,
+        "collected": true,
+        "main_session_source_mutation": false,
+        "modified_paths": [
+          "src/adapters/alpha.js",
+          "src/adapters/bravo.js",
+          "src/adapters/charlie.js",
+          "src/adapters/delta.js",
+          "src/adapters/echo.js",
+          "src/adapters/foxtrot.js",
+          "src/adapters/golf.js",
+          "src/adapters/hotel.js",
+          "src/adapters/india.js",
+          "src/adapters/juliet.js",
+          "src/adapters/kilo.js",
+          "src/adapters/lima.js"
+        ],
+        "tests": "12 passed, 0 failed",
+        "client_reported_cost_usd": 0.4206908,
+        "raw_stream_sha256": "39860fab24432d7315a048e37f68de10466f9ba044214711f00b6892a2238c7b"
+      }
+    },
+    {
+      "id": "compact-policy-schema-a-turn-1",
+      "source_pointer": "/results/schema_lifecycle/attempts/0/turn_1",
+      "cell": "schema_lifecycle",
+      "attempt_id": "a",
+      "turn": "turn_1",
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "0045951f4199f3d3d7285ce4d5780921141863df9a4ac1ac91729c23b6d22155",
+        "fixture_sha256": "a94d2327102ca46ac35fe0af1a57ef17855910e205cb619d43f62b852ee9b46f",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata",
+        "session_binding": {
+          "sanitized_session_id_sha256": "edee6ed500d68409fa60319b352ed7e671f6211bea593888071edb99f2ba3db0",
+          "turn_1_invocation": "--session-id",
+          "turn_2_invocation": "--resume"
+        }
+      },
+      "status": "passed",
+      "record": {
+        "plan_verifier_calls": 1,
+        "invocation_model_present": false,
+        "foreground": true,
+        "collected": true,
+        "verdict": "READY",
+        "writes_before_approval": false,
+        "stopped_for_approval": true,
+        "client_reported_cost_usd": 0.39300275,
+        "raw_stream_sha256": "b20e7ec395f4e382a16ddb37c47a5b11178b4b3036d0a56ac5cc7c255ce7b137"
+      }
+    },
+    {
+      "id": "compact-policy-schema-a-turn-2",
+      "source_pointer": "/results/schema_lifecycle/attempts/0/turn_2",
+      "cell": "schema_lifecycle",
+      "attempt_id": "a",
+      "turn": "turn_2",
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "9fe70e6276b2d5cb26b29d4d23cdbfb62dd7f229788307d1c9794b1ff55813a7",
+        "fixture_sha256": "a94d2327102ca46ac35fe0af1a57ef17855910e205cb619d43f62b852ee9b46f",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata",
+        "session_binding": {
+          "sanitized_session_id_sha256": "edee6ed500d68409fa60319b352ed7e671f6211bea593888071edb99f2ba3db0",
+          "turn_1_invocation": "--session-id",
+          "turn_2_invocation": "--resume"
+        }
+      },
+      "status": "passed",
+      "record": {
+        "implementation_route": "main_session_direct",
+        "execution_agent_calls": 0,
+        "primary_tests": "4 passed, 0 failed",
+        "primary_tests_before_verifier": true,
+        "verifier_calls": 1,
+        "verifier_invocation_model_present": false,
+        "verifier_foreground": true,
+        "verifier_collected": true,
+        "verifier_verdict": "CONFIRMED",
+        "modified_paths": [
+          "store.mjs",
+          "store.test.mjs"
+        ],
+        "client_reported_cost_usd": 0.455531,
+        "raw_stream_sha256": "30dacc355ea6cb89f4d6469fc542f3edece8aa52be4a53d20bebf7ed0bed36eb"
+      }
+    },
+    {
+      "id": "compact-policy-schema-b-turn-1",
+      "source_pointer": "/results/schema_lifecycle/attempts/1/turn_1",
+      "cell": "schema_lifecycle",
+      "attempt_id": "b",
+      "turn": "turn_1",
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "0045951f4199f3d3d7285ce4d5780921141863df9a4ac1ac91729c23b6d22155",
+        "fixture_sha256": "a94d2327102ca46ac35fe0af1a57ef17855910e205cb619d43f62b852ee9b46f",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata",
+        "session_binding": {
+          "sanitized_session_id_sha256": "bdf38bad531db15d2921e2ccc9e863ffdf16938e1abb5275fbd613a1cdd1921a",
+          "turn_1_invocation": "--session-id",
+          "turn_2_invocation": "--resume"
+        }
+      },
+      "status": "passed",
+      "record": {
+        "plan_verifier_calls": 1,
+        "invocation_model_present": false,
+        "foreground": true,
+        "collected": true,
+        "verdict": "READY",
+        "writes_before_approval": false,
+        "stopped_for_approval": true,
+        "client_reported_cost_usd": 0.39499925,
+        "raw_stream_sha256": "cea572b45bd7b2467010e0f136c451d64b66893bdd1e652f302f1adf0c25adf7"
+      }
+    },
+    {
+      "id": "compact-policy-schema-b-turn-2",
+      "source_pointer": "/results/schema_lifecycle/attempts/1/turn_2",
+      "cell": "schema_lifecycle",
+      "attempt_id": "b",
+      "turn": "turn_2",
+      "configuration_identity": {
+        "candidate_sha256": "d7fc88bf7903c2f70581068bfe3c4decea16cbb6470f860907bb856a2d718364",
+        "candidate_base_head": "c1542b758f9b0bcedb29c8ca0ae5b0b88cb39c97",
+        "candidate_version_marker": "1.3.9",
+        "candidate_bytes": 15841,
+        "runtime_loaded_sha256": null,
+        "agents_file_sha256": "e6257911a02c805147d7d8923eae14877cc8e29089e85ac93b544f5afb73ea3f",
+        "agents_runtime_sha256": "b5dc352f526f0c6f1985c67799f547c3368b2b72e77be1738a8789c542ae7bfc",
+        "prompt_runtime_sha256": "9fe70e6276b2d5cb26b29d4d23cdbfb62dd7f229788307d1c9794b1ff55813a7",
+        "fixture_sha256": "a94d2327102ca46ac35fe0af1a57ef17855910e205cb619d43f62b852ee9b46f",
+        "requested_main_model": "opus",
+        "observed_main_model": "claude-opus-5",
+        "effort": "high",
+        "client_versions": [
+          "2.1.224"
+        ],
+        "setting_sources": [
+          "project",
+          "local"
+        ],
+        "provider_route": "native Claude first-party authentication",
+        "account_plan": "Max; the client streams do not emit account-plan metadata",
+        "session_binding": {
+          "sanitized_session_id_sha256": "bdf38bad531db15d2921e2ccc9e863ffdf16938e1abb5275fbd613a1cdd1921a",
+          "turn_1_invocation": "--session-id",
+          "turn_2_invocation": "--resume"
+        }
+      },
+      "status": "passed",
+      "record": {
+        "implementation_route": "main_session_direct",
+        "execution_agent_calls": 0,
+        "primary_tests": "4 passed, 0 failed",
+        "primary_tests_before_verifier": true,
+        "verifier_calls": 1,
+        "verifier_invocation_model_present": false,
+        "verifier_foreground": true,
+        "verifier_collected": true,
+        "verifier_verdict": "CONFIRMED",
+        "modified_paths": [
+          "store.mjs",
+          "store.test.mjs"
+        ],
+        "client_reported_cost_usd": 0.44571925,
+        "raw_stream_sha256": "8ccdc7548adfb967c717b3ddbae7fecc63c89aaf87d1d7e36131a4aadb7775e6"
+      }
+    }
+  ],
+  "failed_attempts": [],
+  "not_run": []
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -1825,6 +1825,253 @@ class PolicyContractTests(unittest.TestCase):
         }
         self.assertEqual(len(hashes), 10)
 
+    def test_compact_policy_full_matrix_attempts_are_source_bound(self) -> None:
+        benchmark = ROOT / "benchmarks" / "spontaneous-dispatch"
+        ledger = json.loads(
+            (benchmark / "compact-policy-full-matrix.attempts.json").read_text(
+                encoding="utf-8"
+            ),
+            parse_float=Decimal,
+        )
+        source_bytes = (benchmark / "compact-policy-full-matrix.json").read_bytes()
+        source = json.loads(source_bytes, parse_float=Decimal)
+        pointers = [
+            "/results/routine_docs/attempts/0",
+            "/results/routine_docs/attempts/1",
+            "/results/single_unknown_bug/attempts/0",
+            "/results/single_unknown_bug/attempts/1",
+            "/results/mechanical_repetition/attempts/0",
+            "/results/mechanical_repetition/attempts/1",
+            "/results/schema_lifecycle/attempts/0/turn_1",
+            "/results/schema_lifecycle/attempts/0/turn_2",
+            "/results/schema_lifecycle/attempts/1/turn_1",
+            "/results/schema_lifecycle/attempts/1/turn_2",
+        ]
+        specs = [
+            ("compact-policy-routine-a", pointers[0], "routine_docs", "a", None, "routine", "routine_and_schema", None),
+            ("compact-policy-routine-b", pointers[1], "routine_docs", "b", None, "routine", "routine_and_schema", None),
+            ("compact-policy-bug-a", pointers[2], "single_unknown_bug", "a", None, "bug", "single_unknown_bug", None),
+            ("compact-policy-bug-b", pointers[3], "single_unknown_bug", "b", None, "bug", "single_unknown_bug", None),
+            ("compact-policy-mechanical-a", pointers[4], "mechanical_repetition", "a", None, "mechanical", "mechanical_repetition", None),
+            ("compact-policy-mechanical-b", pointers[5], "mechanical_repetition", "b", None, "mechanical", "mechanical_repetition", None),
+            ("compact-policy-schema-a-turn-1", pointers[6], "schema_lifecycle", "a", "turn_1", "schema_turn_1", "routine_and_schema", 0),
+            ("compact-policy-schema-a-turn-2", pointers[7], "schema_lifecycle", "a", "turn_2", "schema_turn_2", "routine_and_schema", 0),
+            ("compact-policy-schema-b-turn-1", pointers[8], "schema_lifecycle", "b", "turn_1", "schema_turn_1", "routine_and_schema", 1),
+            ("compact-policy-schema-b-turn-2", pointers[9], "schema_lifecycle", "b", "turn_2", "schema_turn_2", "routine_and_schema", 1),
+        ]
+
+        def resolve(pointer: str) -> dict:
+            value: object = source
+            for token in pointer.removeprefix("/").split("/"):
+                if isinstance(value, dict):
+                    self.assertIn(token, value)
+                    value = value[token]
+                elif isinstance(value, list):
+                    self.assertTrue(token.isdigit())
+                    value = value[int(token)]
+                else:
+                    self.fail(f"cannot resolve {pointer!r}")
+            self.assertIsInstance(value, dict)
+            return value
+
+        def identity(prompt: str, fixture: str, schema_index: int | None) -> dict:
+            result = {
+                "candidate_sha256": source["candidate"]["sha256"],
+                "candidate_base_head": source["candidate"]["base_head"],
+                "candidate_version_marker": source["candidate"]["version_marker"],
+                "candidate_bytes": source["candidate"]["bytes"],
+                "runtime_loaded_sha256": source["candidate"][
+                    "runtime_loaded_sha256"
+                ],
+                "agents_file_sha256": source["agents"]["file_sha256"],
+                "agents_runtime_sha256": source["agents"]["runtime_sha256"],
+                "prompt_runtime_sha256": source["inputs"][
+                    "prompt_runtime_sha256"
+                ][prompt],
+                "fixture_sha256": source["inputs"]["fixture_sha256"][fixture],
+                **{
+                    key: source["route"][key]
+                    for key in (
+                        "requested_main_model",
+                        "observed_main_model",
+                        "effort",
+                        "client_versions",
+                        "setting_sources",
+                        "provider_route",
+                        "account_plan",
+                    )
+                },
+            }
+            if schema_index is not None:
+                result["session_binding"] = source["results"]["schema_lifecycle"][
+                    "attempts"
+                ][schema_index]["session_binding"]
+            return result
+
+        def expected_entry(spec: tuple) -> dict:
+            entry_id, pointer, cell, attempt_id, turn, prompt, fixture, index = spec
+            return {
+                "id": entry_id,
+                "source_pointer": pointer,
+                "cell": cell,
+                "attempt_id": attempt_id,
+                "turn": turn,
+                "configuration_identity": identity(prompt, fixture, index),
+                "status": "passed",
+                "record": resolve(pointer),
+            }
+
+        def validate(candidate: dict) -> None:
+            self.assertEqual(
+                set(source),
+                {
+                    "schema_version",
+                    "status",
+                    "run_date",
+                    "claim",
+                    "claim_boundary",
+                    "candidate",
+                    "agents",
+                    "inputs",
+                    "route",
+                    "budget",
+                    "results",
+                },
+            )
+            self.assertEqual(source["status"], "passed")
+            self.assertIsNone(source["candidate"]["runtime_loaded_sha256"])
+            self.assertEqual(
+                list(source["results"]),
+                [
+                    "routine_docs",
+                    "single_unknown_bug",
+                    "mechanical_repetition",
+                    "schema_lifecycle",
+                ],
+            )
+            for cell in source["results"].values():
+                self.assertEqual(cell["status"], "passed")
+                self.assertEqual(len(cell["attempts"]), 2)
+            self.assertEqual(
+                set(candidate),
+                {
+                    "schema_version",
+                    "source",
+                    "counts",
+                    "coverage",
+                    "passed_attempts",
+                    "failed_attempts",
+                    "not_run",
+                },
+            )
+            self.assertEqual(candidate["schema_version"], 1)
+            self.assertEqual(
+                candidate["source"],
+                {
+                    "path": "compact-policy-full-matrix.json",
+                    "sha256": hashlib.sha256(source_bytes).hexdigest(),
+                },
+            )
+            self.assertEqual(
+                candidate["counts"], {"attempted": 10, "passed": 10, "failed": 0}
+            )
+            self.assertEqual(
+                candidate["coverage"],
+                {"source_pointer": "/results", "invocation_pointers": pointers},
+            )
+            self.assertEqual(candidate["failed_attempts"], [])
+            self.assertEqual(candidate["not_run"], [])
+            self.assertEqual(
+                candidate["passed_attempts"],
+                [expected_entry(spec) for spec in specs],
+            )
+            entries = candidate["passed_attempts"]
+            self.assertEqual(len({entry["id"] for entry in entries}), 10)
+            self.assertEqual(len({entry["source_pointer"] for entry in entries}), 10)
+            self.assertEqual(
+                sum(entry["record"]["client_reported_cost_usd"] for entry in entries),
+                source["budget"]["actual_usd"],
+            )
+            self.assertEqual(
+                len({entry["record"]["raw_stream_sha256"] for entry in entries}),
+                10,
+            )
+            self.assertTrue(
+                all("/agent_calls/" not in pointer for pointer in pointers)
+            )
+            self.assertEqual(
+                sum(
+                    entry["record"].get("agent_calls", 0)
+                    + entry["record"].get("plan_verifier_calls", 0)
+                    + entry["record"].get("verifier_calls", 0)
+                    for entry in entries
+                ),
+                6,
+            )
+            for index in (0, 1):
+                first = entries[6 + 2 * index]
+                second = entries[7 + 2 * index]
+                self.assertEqual(first["turn"], "turn_1")
+                self.assertEqual(second["turn"], "turn_2")
+                self.assertEqual(
+                    first["configuration_identity"]["session_binding"],
+                    second["configuration_identity"]["session_binding"],
+                )
+
+        validate(ledger)
+
+        missing = deepcopy(ledger)
+        missing["passed_attempts"].pop()
+        with self.assertRaises(AssertionError):
+            validate(missing)
+
+        aggregate = deepcopy(ledger)
+        aggregate["coverage"]["invocation_pointers"][0] = "/results/routine_docs"
+        with self.assertRaises(AssertionError):
+            validate(aggregate)
+
+        flipped = deepcopy(ledger)
+        flipped["passed_attempts"][0]["status"] = "failed"
+        with self.assertRaises(AssertionError):
+            validate(flipped)
+
+        for target, key, value in (
+            ("configuration_identity", "candidate_sha256", "0" * 64),
+            ("configuration_identity", "prompt_runtime_sha256", "0" * 64),
+            ("configuration_identity", "fixture_sha256", "0" * 64),
+            ("record", "raw_stream_sha256", "0" * 64),
+            ("record", "client_reported_cost_usd", Decimal("0")),
+        ):
+            replaced = deepcopy(ledger)
+            replaced["passed_attempts"][0][target][key] = value
+            with self.assertRaises(AssertionError):
+                validate(replaced)
+
+        replaced_session = deepcopy(ledger)
+        replaced_session["passed_attempts"][6]["configuration_identity"][
+            "session_binding"
+        ]["sanitized_session_id_sha256"] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(replaced_session)
+
+        collapsed_schema = deepcopy(ledger)
+        collapsed_schema["passed_attempts"].pop(7)
+        collapsed_schema["counts"] = {"attempted": 9, "passed": 9, "failed": 0}
+        with self.assertRaises(AssertionError):
+            validate(collapsed_schema)
+
+        child_inflated = deepcopy(ledger)
+        child_inflated["counts"] = {"attempted": 16, "passed": 16, "failed": 0}
+        with self.assertRaises(AssertionError):
+            validate(child_inflated)
+
+        invented_runtime_digest = deepcopy(ledger)
+        invented_runtime_digest["passed_attempts"][0]["configuration_identity"][
+            "runtime_loaded_sha256"
+        ] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(invented_runtime_digest)
+
     def test_spontaneous_dispatch_baseline_is_additive_and_evidence_bound(self) -> None:
         benchmark = ROOT / "benchmarks" / "spontaneous-dispatch"
         results = json.loads((benchmark / "results.json").read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary

- add a SHA-bound source-native ledger for all 10 compact-policy matrix CLI invocations
- preserve schema turn 1 and resumed turn 2 as separate records with shared session identity
- keep six child role calls as metadata rather than attempt counts
- bind every record to candidate, agent, prompt, fixture, and route identity without inventing a runtime-loaded policy digest

## Verification

- focused compact-matrix attempt contract
- full repository suite: 78/78
- renderer `--check`, Python syntax, strict JSON duplicate-key parse
- source SHA-256 unchanged: `ac3f4dabaabb17f3519d27f7841b1c144de347854df2efdd6746016668ca41a2`
- exact two-path scope and `git diff --check`
- fresh verifier: `CONFIRMED` with cross-session substitution tamper

No live or paid gate was run. Part of #65.