### PR TITLE
feat(benchmarks): bind verifier paid summaries

### DIFF
--- a/benchmarks/verifier-boundary/paid-campaign.summary.json
+++ b/benchmarks/verifier-boundary/paid-campaign.summary.json
@@ -4,8 +4,9 @@
     "path": "results.json",
     "sha256": "574fe0dcc78e0abf4faf4fb6895ecc7cf5fba964f3fbb0b6987f5d4779f87430"
   },
-  "claim_boundary": "These records are cost aggregates grouped by policy bytes. Invocation cardinality is unknown for every group, so they do not define attempt counts, rates, or complete group outcomes. at_least_one_pass and at_least_one_failure are source-supported lower bounds only; passed is used only where the aggregate cost exactly equals the complete passing gate.",
+  "claim_boundary": "These records are cost/run-category aggregates labeled by policy SHA prefix. Suffixes such as diagnostic and reproduction subdivide runs against the same policy bytes, so group_count is not a distinct-policy count. Invocation cardinality is unknown for every group, so they do not define attempt counts, rates, or complete group outcomes. at_least_one_pass and at_least_one_failure are source-supported lower bounds only; passed is used only where the aggregate cost exactly equals the complete passing gate.",
   "summary": {
+    "group_kind": "cost_run_category",
     "group_count": 10,
     "total_client_reported_cost_usd": 29.83550685
   },

--- a/benchmarks/verifier-boundary/paid-campaign.summary.json
+++ b/benchmarks/verifier-boundary/paid-campaign.summary.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": 1,
+  "source": {
+    "path": "results.json",
+    "sha256": "574fe0dcc78e0abf4faf4fb6895ecc7cf5fba964f3fbb0b6987f5d4779f87430"
+  },
+  "claim_boundary": "These records are cost aggregates grouped by policy bytes. Invocation cardinality is unknown for every group, so they do not define attempt counts, rates, or complete group outcomes. at_least_one_pass and at_least_one_failure are source-supported lower bounds only; passed is used only where the aggregate cost exactly equals the complete passing gate.",
+  "summary": {
+    "group_count": 10,
+    "total_client_reported_cost_usd": 29.83550685
+  },
+  "groups": [
+    {
+      "id": "verifier-paid-group-0",
+      "source_pointer": "/paid_campaign/attempt_log/0",
+      "invocation_count": "unknown",
+      "recorded_outcome": "at_least_one_failure",
+      "outcome_evidence_pointers": [
+        "/failed_attempts/2"
+      ],
+      "record": {
+        "policy_sha256_prefix": "59f18c6d",
+        "client_reported_cost_usd": 2.813526
+      }
+    },
+    {
+      "id": "verifier-paid-group-1",
+      "source_pointer": "/paid_campaign/attempt_log/1",
+      "invocation_count": "unknown",
+      "recorded_outcome": "outcome_unknown_quota_terminated",
+      "outcome_evidence_pointers": [
+        "/failed_attempts/2/inconclusive_diagnostic"
+      ],
+      "record": {
+        "policy_sha256_prefix": "59f18c6d-diagnostic",
+        "client_reported_cost_usd": 0.37431
+      }
+    },
+    {
+      "id": "verifier-paid-group-2",
+      "source_pointer": "/paid_campaign/attempt_log/2",
+      "invocation_count": "unknown",
+      "recorded_outcome": "at_least_one_pass",
+      "outcome_evidence_pointers": [
+        "/failed_attempts/2/same_bytes_later_reproduced"
+      ],
+      "record": {
+        "policy_sha256_prefix": "59f18c6d-reproduction",
+        "client_reported_cost_usd": 1.147222
+      }
+    },
+    {
+      "id": "verifier-paid-group-3",
+      "source_pointer": "/paid_campaign/attempt_log/3",
+      "invocation_count": "unknown",
+      "recorded_outcome": "unknown",
+      "outcome_evidence_pointers": [],
+      "record": {
+        "policy_sha256_prefix": "69ed7ffc",
+        "client_reported_cost_usd": 2.314099
+      }
+    },
+    {
+      "id": "verifier-paid-group-4",
+      "source_pointer": "/paid_campaign/attempt_log/4",
+      "invocation_count": "unknown",
+      "recorded_outcome": "at_least_one_failure",
+      "outcome_evidence_pointers": [
+        "/failed_attempts/3"
+      ],
+      "record": {
+        "policy_sha256_prefix": "6b1e8095-shipped",
+        "client_reported_cost_usd": 3.989178
+      }
+    },
+    {
+      "id": "verifier-paid-group-5",
+      "source_pointer": "/paid_campaign/attempt_log/5",
+      "invocation_count": "unknown",
+      "recorded_outcome": "unknown",
+      "outcome_evidence_pointers": [],
+      "record": {
+        "policy_sha256_prefix": "6f3d513b",
+        "client_reported_cost_usd": 3.99375
+      }
+    },
+    {
+      "id": "verifier-paid-group-6",
+      "source_pointer": "/paid_campaign/attempt_log/6",
+      "invocation_count": "unknown",
+      "recorded_outcome": "unknown",
+      "outcome_evidence_pointers": [],
+      "record": {
+        "policy_sha256_prefix": "84309e9b",
+        "client_reported_cost_usd": 2.613567
+      }
+    },
+    {
+      "id": "verifier-paid-group-7",
+      "source_pointer": "/paid_campaign/attempt_log/7",
+      "invocation_count": "unknown",
+      "recorded_outcome": "unknown",
+      "outcome_evidence_pointers": [],
+      "record": {
+        "policy_sha256_prefix": "8cec947e",
+        "client_reported_cost_usd": 3.589613
+      }
+    },
+    {
+      "id": "verifier-paid-group-8",
+      "source_pointer": "/paid_campaign/attempt_log/8",
+      "invocation_count": "unknown",
+      "recorded_outcome": "at_least_one_pass",
+      "outcome_evidence_pointers": [
+        "/superseded_v1_3_6_passing_gate/status"
+      ],
+      "record": {
+        "policy_sha256_prefix": "v1_3_6_baseline",
+        "client_reported_cost_usd": 5.1607271
+      }
+    },
+    {
+      "id": "verifier-paid-group-9",
+      "source_pointer": "/paid_campaign/attempt_log/9",
+      "invocation_count": "unknown",
+      "recorded_outcome": "passed",
+      "outcome_evidence_pointers": [
+        "/passing_gate/status"
+      ],
+      "record": {
+        "policy_sha256_prefix": "b26ef4a6-shipped-verified",
+        "client_reported_cost_usd": 3.83951475
+      }
+    }
+  ]
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -3775,12 +3775,14 @@ class PolicyContractTests(unittest.TestCase):
             ("passed", ["/passing_gate/status"]),
         ]
         claim_boundary = (
-            "These records are cost aggregates grouped by policy bytes. Invocation "
-            "cardinality is unknown for every group, so they do not define attempt "
-            "counts, rates, or complete group outcomes. at_least_one_pass and "
-            "at_least_one_failure are source-supported lower bounds only; passed is "
-            "used only where the aggregate cost exactly equals the complete passing "
-            "gate."
+            "These records are cost/run-category aggregates labeled by policy SHA "
+            "prefix. Suffixes such as diagnostic and reproduction subdivide runs "
+            "against the same policy bytes, so group_count is not a distinct-policy "
+            "count. Invocation cardinality is unknown for every group, so they do "
+            "not define attempt counts, rates, or complete group outcomes. "
+            "at_least_one_pass and at_least_one_failure are source-supported lower "
+            "bounds only; passed is used only where the aggregate cost exactly "
+            "equals the complete passing gate."
         )
 
         def resolve(pointer: str) -> object:
@@ -3834,6 +3836,7 @@ class PolicyContractTests(unittest.TestCase):
             self.assertEqual(
                 candidate["summary"],
                 {
+                    "group_kind": "cost_run_category",
                     "group_count": 10,
                     "total_client_reported_cost_usd": source["paid_campaign"][
                         "client_reported_cost_usd"

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -3745,6 +3745,170 @@ class PolicyContractTests(unittest.TestCase):
         with self.assertRaises(AssertionError):
             validate(reordered)
 
+    def test_verifier_paid_campaign_summary_is_source_bound(self) -> None:
+        gate = ROOT / "benchmarks" / "verifier-boundary"
+        summary = json.loads(
+            (gate / "paid-campaign.summary.json").read_text(encoding="utf-8"),
+            parse_float=Decimal,
+        )
+        source_bytes = (gate / "results.json").read_bytes()
+        source = json.loads(source_bytes, parse_float=Decimal)
+        semantics = [
+            ("at_least_one_failure", ["/failed_attempts/2"]),
+            (
+                "outcome_unknown_quota_terminated",
+                ["/failed_attempts/2/inconclusive_diagnostic"],
+            ),
+            (
+                "at_least_one_pass",
+                ["/failed_attempts/2/same_bytes_later_reproduced"],
+            ),
+            ("unknown", []),
+            ("at_least_one_failure", ["/failed_attempts/3"]),
+            ("unknown", []),
+            ("unknown", []),
+            ("unknown", []),
+            (
+                "at_least_one_pass",
+                ["/superseded_v1_3_6_passing_gate/status"],
+            ),
+            ("passed", ["/passing_gate/status"]),
+        ]
+        claim_boundary = (
+            "These records are cost aggregates grouped by policy bytes. Invocation "
+            "cardinality is unknown for every group, so they do not define attempt "
+            "counts, rates, or complete group outcomes. at_least_one_pass and "
+            "at_least_one_failure are source-supported lower bounds only; passed is "
+            "used only where the aggregate cost exactly equals the complete passing "
+            "gate."
+        )
+
+        def resolve(pointer: str) -> object:
+            value: object = source
+            for token in pointer.removeprefix("/").split("/"):
+                if isinstance(value, dict):
+                    self.assertIn(token, value)
+                    value = value[token]
+                elif isinstance(value, list):
+                    self.assertTrue(token.isdigit())
+                    value = value[int(token)]
+                else:
+                    self.fail(f"cannot resolve {pointer!r}")
+            return value
+
+        expected_groups = [
+            {
+                "id": f"verifier-paid-group-{index}",
+                "source_pointer": f"/paid_campaign/attempt_log/{index}",
+                "invocation_count": "unknown",
+                "recorded_outcome": outcome,
+                "outcome_evidence_pointers": evidence,
+                "record": record,
+            }
+            for index, (record, (outcome, evidence)) in enumerate(
+                zip(source["paid_campaign"]["attempt_log"], semantics)
+            )
+        ]
+
+        def validate(candidate: dict) -> None:
+            self.assertEqual(source["schema_version"], 2)
+            self.assertEqual(candidate["schema_version"], 1)
+            self.assertEqual(
+                set(candidate),
+                {
+                    "schema_version",
+                    "source",
+                    "claim_boundary",
+                    "summary",
+                    "groups",
+                },
+            )
+            self.assertEqual(
+                candidate["source"],
+                {
+                    "path": "results.json",
+                    "sha256": hashlib.sha256(source_bytes).hexdigest(),
+                },
+            )
+            self.assertEqual(candidate["claim_boundary"], claim_boundary)
+            self.assertEqual(
+                candidate["summary"],
+                {
+                    "group_count": 10,
+                    "total_client_reported_cost_usd": source["paid_campaign"][
+                        "client_reported_cost_usd"
+                    ],
+                },
+            )
+            self.assertEqual(candidate["groups"], expected_groups)
+            self.assertEqual(
+                sum(group["record"]["client_reported_cost_usd"] for group in candidate["groups"]),
+                candidate["summary"]["total_client_reported_cost_usd"],
+            )
+            self.assertTrue(
+                all(group["invocation_count"] == "unknown" for group in candidate["groups"])
+            )
+            self.assertEqual(
+                [
+                    index
+                    for index, group in enumerate(candidate["groups"])
+                    if group["recorded_outcome"] == "passed"
+                ],
+                [9],
+            )
+            self.assertTrue(resolve(candidate["groups"][2]["outcome_evidence_pointers"][0]))
+            self.assertEqual(
+                candidate["groups"][9]["record"]["client_reported_cost_usd"],
+                source["passing_gate"]["client_reported_cost_usd"],
+            )
+            self.assertEqual(resolve("/passing_gate/status"), "passed")
+            self.assertEqual(
+                resolve("/superseded_v1_3_6_passing_gate/status"), "passed"
+            )
+            for group in candidate["groups"]:
+                for pointer in group["outcome_evidence_pointers"]:
+                    self.assertIsNotNone(resolve(pointer))
+            forbidden = {"attempted", "passed", "failed", "rate", "attempt_count"}
+            self.assertTrue(forbidden.isdisjoint(candidate["summary"]))
+            self.assertEqual(
+                hashlib.sha256((gate / "attempts.json").read_bytes()).hexdigest(),
+                "96b875c2eff91faf8bca9d4d582ca86a45998b18626c2b491478fc4911f4c49d",
+            )
+
+        validate(summary)
+
+        promoted = deepcopy(summary)
+        promoted["groups"][2]["recorded_outcome"] = "passed"
+        with self.assertRaises(AssertionError):
+            validate(promoted)
+
+        cardinalized = deepcopy(summary)
+        cardinalized["groups"][0]["invocation_count"] = 1
+        with self.assertRaises(AssertionError):
+            validate(cardinalized)
+
+        remapped = deepcopy(summary)
+        remapped["groups"][4]["outcome_evidence_pointers"] = [
+            "/passing_gate/status"
+        ]
+        with self.assertRaises(AssertionError):
+            validate(remapped)
+
+        changed_cost = deepcopy(summary)
+        changed_cost["groups"][9]["record"]["client_reported_cost_usd"] = Decimal("0")
+        with self.assertRaises(AssertionError):
+            validate(changed_cost)
+
+        missing = deepcopy(summary)
+        missing["groups"].pop()
+        with self.assertRaises(AssertionError):
+            validate(missing)
+
+        changed_source = deepcopy(summary)
+        changed_source["source"]["sha256"] = "0" * 64
+        with self.assertRaises(AssertionError):
+            validate(changed_source)
+
     def test_prompt_template_semantic_equivalence_gate_is_documented(self) -> None:
         contributing = (ROOT / "CONTRIBUTING.md").read_text(encoding="utf-8")
         release = (ROOT / "RELEASING.md").read_text(encoding="utf-8")


### PR DESCRIPTION
## Summary

- add a source-bound cost-summary contract for all 10 paid campaign groups
- keep invocation cardinality unknown and expose no attempt totals or rates
- preserve only source-supported lower-bound outcomes; group 9 alone is fully `passed`
- keep the merged detailed-attempt ledger byte-identical

This is the paid-summary half of the split approved after closed no-go PR #80.

## Verification

- focused paid-summary contract
- full repository suite: 82/82
- renderer, Python/JSON syntax, and `git diff --check`
- source SHA unchanged: `574fe0dcc78e0abf4faf4fb6895ecc7cf5fba964f3fbb0b6987f5d4779f87430`
- detailed ledger SHA unchanged: `96b875c2eff91faf8bca9d4d582ca86a45998b18626c2b491478fc4911f4c49d`
- exact two-path scope
- fresh verifier: `CONFIRMED`

No live or paid gate was run. Completes the planned #65 source contracts.